### PR TITLE
Fixes several issues related to ranges

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -262,7 +262,6 @@ such that a null value is valid.
 <code>range::[ <i>&lt;RANGE_TYPE&gt;</i>, <i>&lt;RANGE_TYPE&gt;</i> ]</code><br/>
 <code>range::[ min, <i>&lt;RANGE_TYPE&gt;</i> ]</code><br/>
 <code>range::[ <i>&lt;RANGE_TYPE&gt;</i>, max ]</code><br/>
-<code>range::[ min, max ]</code>
 
 Some constraints can be defined by a range. A range is represented by a
 list annotated with `range`, and containing two values, in order: the
@@ -272,6 +271,7 @@ the minimum or maximum (or both) values shall be annotated with `exclusive`.
 If the minimum or maximum end of a range is to be unspecified, this shall
 be represented by the symbols `min` or `max`, respectively; the `exclusive`
 annotation is not applicable when the symbols `min` or `max` are specified.
+A range may not contain both `min` and `max`.
 
 > ```
 > range::[5, max]                        // minimum 5, maximum unbound
@@ -842,7 +842,6 @@ This section provides a BNF-style grammar for the Ion Schema Language.
 <RANGE<RANGE_TYPE>> ::= range::[ <RANGE_TYPE>, <RANGE_TYPE> ]
                       | range::[ min, <RANGE_TYPE> ]
                       | range::[ <RANGE_TYPE>, max ]
-                      | range::[ min, max ]
 
 <CONSTRAINT> ::= <ALL_OF>
                | <ANNOTATIONS>

--- a/spec.md
+++ b/spec.md
@@ -499,8 +499,8 @@ and 59, inclusive.
 <code><b>timestamp_precision:</b> <i>&lt;TIMESTAMP_PRECISION_VALUE&gt;</i></code><br/>
 <code><b>timestamp_precision:</b> <i>&lt;RANGE&lt;TIMESTAMP_PRECISION_VALUE&gt;&gt;</i></code>
 
-Indicates the exact or minimum/maximum (inclusive) precision of a
-timestamp. Valid precision values are, in order of increasing precision:
+Indicates the exact or minimum/maximum precision of a timestamp.
+Valid precision values are, in order of increasing precision:
 `year`, `month`, `day`, `minute`, `second`, `millisecond`, `microsecond`, and `nanosecond`.
 
 > ```
@@ -509,6 +509,8 @@ timestamp. Valid precision values are, in order of increasing precision:
 > timestamp_precision: range::[month, max]
 > timestamp_precision: range::[min, day]
 > timestamp_precision: range::[second, nanosecond]
+> timestamp_precision: range::[exclusive::second, max]  // any timestamp with fractional seconds is allowed
+> timestamp_precision: range::[exclusive::second, exclusive::millisecond]  // only timestamps with a precision of tenths or hundredths of a second are allowed
 > timestamp_precision: range::[month, day]
 > timestamp_precision: range::[year, day]
 > ```

--- a/spec.md
+++ b/spec.md
@@ -274,11 +274,12 @@ annotation is not applicable when the symbols `min` or `max` are specified.
 A range may not contain both `min` and `max`.
 
 > ```
-> range::[5, max]                        // minimum 5, maximum unbound
-> range::[min, 7]                        // minimum unbound, maximum 7
-> range::[5, 7]                          // between 5 and 7, inclusive
-> range::[exclusive::5, exclusive::7]    // only 6 is valid
-> range::[5.5, 7.9]                      // between 5.5 and 7.9, inclusive
+> range::[5, max]                               // minimum 5, maximum unbound
+> range::[min, 7]                               // minimum unbound, maximum 7
+> range::[5, 7]                                 // between 5 and 7, inclusive
+> range::[exclusive::5, exclusive::7]           // only 6 is valid
+> range::[5.5, 7.9]                             // between 5.5 and 7.9, inclusive
+> range::[2019-01-01T, exclusive::2020-01-01T]  // any timestamp in the year 2019
 > ```
 
 ## General Constraints
@@ -837,6 +838,7 @@ This section provides a BNF-style grammar for the Ion Schema Language.
                | <FLOAT>
                | <INT>
                | <NUMBER>
+               | <TIMESTAMP>
                | <TIMESTAMP_PRECISION_VALUE>
 
 <EXCLUSIVITY> ::= exclusive::
@@ -939,6 +941,7 @@ This section provides a BNF-style grammar for the Ion Schema Language.
 
 <VALID_VALUES> ::= valid_values: [ <VALUE>... ]
                  | valid_values: <RANGE<NUMBER>>
+                 | valid_values: <RANGE<TIMESTAMP>>
 
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -259,9 +259,9 @@ such that a null value is valid.
 
 #### Ranges
 
-<code>range::[ <i>&lt;RANGE_TYPE&gt;</i>, <i>&lt;RANGE_TYPE&gt;</i> ]</code><br/>
-<code>range::[ min, <i>&lt;RANGE_TYPE&gt;</i> ]</code><br/>
-<code>range::[ <i>&lt;RANGE_TYPE&gt;</i>, max ]</code><br/>
+<code>range::[ <i>&lt;EXCLUSIVITY&gt;&lt;RANGE_TYPE&gt;</i>, <i>&lt;EXCLUSIVITY&gt;&lt;RANGE_TYPE&gt;</i> ]</code><br/>
+<code>range::[ min, <i>&lt;EXCLUSIVITY&gt;&lt;RANGE_TYPE&gt;</i> ]</code><br/>
+<code>range::[ <i>&lt;EXCLUSIVITY&gt;&lt;RANGE_TYPE&gt;</i>, max ]</code><br/>
 
 Some constraints can be defined by a range. A range is represented by a
 list annotated with `range`, and containing two values, in order: the
@@ -839,9 +839,12 @@ This section provides a BNF-style grammar for the Ion Schema Language.
                | <NUMBER>
                | <TIMESTAMP_PRECISION_VALUE>
 
-<RANGE<RANGE_TYPE>> ::= range::[ <RANGE_TYPE>, <RANGE_TYPE> ]
-                      | range::[ min, <RANGE_TYPE> ]
-                      | range::[ <RANGE_TYPE>, max ]
+<EXCLUSIVITY> ::= exclusive::
+                | ""
+
+<RANGE<RANGE_TYPE>> ::= range::[ <EXCLUSIVITY><RANGE_TYPE>, <EXCLUSIVITY><RANGE_TYPE> ]
+                      | range::[ min, <EXCLUSIVITY><RANGE_TYPE> ]
+                      | range::[ <EXCLUSIVITY><RANGE_TYPE>, max ]
 
 <CONSTRAINT> ::= <ALL_OF>
                | <ANNOTATIONS>

--- a/spec.md
+++ b/spec.md
@@ -277,7 +277,7 @@ A range may not contain both `min` and `max`.
 > range::[5, max]                               // minimum 5, maximum unbound
 > range::[min, 7]                               // minimum unbound, maximum 7
 > range::[5, 7]                                 // between 5 and 7, inclusive
-> range::[exclusive::5, exclusive::7]           // only 6 is valid
+> range::[exclusive::5, exclusive::7]           // between 5 and 7, exclusive; if type is also constrained to be an int, only 6 is allowed
 > range::[5.5, 7.9]                             // between 5.5 and 7.9, inclusive
 > range::[2019-01-01T, exclusive::2020-01-01T]  // any timestamp in the year 2019
 > ```


### PR DESCRIPTION
*Issue #, if available:* #3, #4, #6, #7, #8 

*Description of changes:*

Fixes several issues in the spec related to ranges.
* Adds BNF grammar for `exclusive::` and timestamp ranges
* Clarifies that `range::[min,max]` is not valid
* Clarifies a few potentially misleading things regarding `exclusive::`

*Notes/Questions*

I chose to create one commit for each github issue. Is this your preference, or would you prefer that they be squashed into one commit?

There's a few things I noticed that I *could* have included in this PR, but there's no github issue for it (that I can find) and I didn't want to assume the correct course of action. Should I create an issue for these things, or are they fine as is?

* Based on the reference implementation, it seems like an empty range is invalid. Eg. `scale: range::[exclusive::1, exclusive::2]` is invalid—though the same range would be valid in other contexts, such as a `valid_values` constraint on a float. Should the spec contain further clarification regarding when a range will be invalid for being empty? 
* In the reference implementation, it is possible for a timestamp to have a precision of hundredths of a second, but there is no way to represent that using the `timestamp_precision` constraint. The best you can do is `range::[exclusive::second, exclusive::millisecond]`, which will allow timestamps with a precision of tenths or hundredths of a second. Should the spec be more explicit in describing that a timestamp has more possible precision values than those allowed to be used in the constraint?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
