### PR TITLE
adds changes for value order of timestamp and number ranges

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -291,28 +291,28 @@ A `timestamp` with limited precision (for example, a year-only timestamp like `2
 that all unspecified time unit fields are effectively zero (or one for the month and
 day units). `2007T` would map to the instant represented by `2007-01-01T00:00.000-00:00`. 
 Note that `timestamp` values that do not have a time component (that is: `YYYYT`, `YYYY-MMT`, and `YYYY-MM-DDT` 
-timestamps) have an unknown offset (`-00:00`). The timestamps that have an unknown offset are UTC timestamps that
+timestamps) have an unknown offset (`-00:00`). Timestamps that have an unknown offset are UTC timestamps that
 make no assertion about the offset in which they occurred.
    
 > ```
 >  // Timestamp                  Instant
->  2007T                      2007-01-01T00:00.000-00:00
->  2007-05T                   2007-05-01T00:00.000-00:00
->  2007-05-23T                2007-05-23T00:00.000-00:00
->  2007-05-23T:06:15Z         2007-05-01T06:15.000Z
->  2007-05-23T:06:15-00:00    2007-05-01T06:15.000-00:00
->  2007-05-23T:06:15+00:00    2007-05-01T06:15.000+00:00
->  2007-05-23T:06:15+05:00    2007-05-01T06:15.000+05:00
->  2007-05-23T:06:15.945Z     2007-05-01T06:15.945Z   
+>     2007T                      2007-01-01T00:00.000-00:00
+>     2007-05T                   2007-05-01T00:00.000-00:00
+>     2007-05-23T                2007-05-23T00:00.000-00:00
+>     2007-05-23T:06:15Z         2007-05-01T06:15.000Z
+>     2007-05-23T:06:15-00:00    2007-05-01T06:15.000-00:00
+>     2007-05-23T:06:15+00:00    2007-05-01T06:15.000+00:00
+>     2007-05-23T:06:15+05:00    2007-05-01T06:15.000+05:00
+>     2007-05-23T:06:15.945Z     2007-05-01T06:15.945Z   
 > ```
 
 A `timestamp` range includes any `timestamp` that falls between the minimum and maximum in chronological order. 
-The `timestamp` ranges do not include values of any other type.
+`timestamp` ranges do not include values of any other type.
 
 > ```
 > range::[5, max]                               // minimum 5, maximum unbound
 > range::[min, 7]                               // minimum unbound, maximum 7
-> range::[5, 7]                                 // between 5 and 7, inclusive, if type is not constrained to be an int, not only 5, 6, 7 but 5.1, 5.2,... all int, float and decimal values within the range are allowed
+> range::[5, 7]                                 // between 5 and 7, inclusive
 > range::[1.0, 10e]                             // mixing numeric types is allowed
 > range::[exclusive::5, exclusive::7]           // between 5 and 7, exclusive; if type is also constrained to be an int, only 6 is allowed
 > range::[5.5, 7.9]                             // between 5.5 and 7.9, inclusive

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -273,10 +273,19 @@ be represented by the symbols `min` or `max`, respectively; the `exclusive`
 annotation is not applicable when the symbols `min` or `max` are specified.
 A range may not contain both `min` and `max`.
 
+Also, if a range is a `number` range (i.e. type is not constrained) then it allows all the `integer`, `float`, 
+`decimal` values that falls inside the range. For example, even if the range mentioned itself contains just the
+`integer` values as the `min` and `max` bounds of the range, all the `floats` and `decimals` falling within the 
+range are allowed as well.
+
+For `number` and `timestamp` ranges, the value order is determined by converting them to `big decimal` and then
+ checking if the given item falls within that range. When a `timestamp` range is specified, neither end of the range
+  may have an unknown local offset.
+
 > ```
 > range::[5, max]                               // minimum 5, maximum unbound
 > range::[min, 7]                               // minimum unbound, maximum 7
-> range::[5, 7]                                 // between 5 and 7, inclusive
+> range::[5, 7]                                 // between 5 and 7, inclusive, if type is not constrained to be an int, not only 5, 6, 7 but 5.1, 5.2,... all int, float and decimal values within the range are allowed
 > range::[exclusive::5, exclusive::7]           // between 5 and 7, exclusive; if type is also constrained to be an int, only 6 is allowed
 > range::[5.5, 7.9]                             // between 5.5 and 7.9, inclusive
 > range::[2019-01-01T, exclusive::2020-01-01T]  // any timestamp in the year 2019
@@ -338,7 +347,8 @@ expected, `5`, `null`, `null.null`, and `null.int` are valid, but
 ### valid_values
 
 <code><b>valid_values:</b> [ <i>&lt;VALUE&gt;...</i> ]</code><br/>
-<code><b>valid_values:</b> <i>&lt;RANGE&lt;NUMBER&gt;&gt;</i></code>
+<code><b>valid_values:</b> <i>&lt;RANGE&lt;NUMBER&gt;&gt;</i></code><br/>
+<code><b>valid_values:</b> <i>&lt;RANGE&lt;TIMESTAMP&gt;&gt;</i></code>
 
 A list of acceptable, non-annotated values;  any values not present
 in the list are invalid. Whether a particular value matches


### PR DESCRIPTION
*Description of changes:*
This PR works on changes for value order of `timestamp` and `number`.

*Changes:*

- Changes the ranges section to explain on different types allowed within a range. e.g. `int`, `float`, `decimal`,.. allowed within a `number` range
- Changes the valid values value section to include `<RANGE<TIMESTAMP>>` to specify `timestamp` ranges are allowed for valid values.
- Adds how all ranges use value order to determine whether a given item falls within that range.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
