### PR TITLE
Fixes a code snippet typo

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -100,7 +100,7 @@ The core types do not include any of Ion's `null.*` values, but each of the
 types may have a weakly- or strongly-typed null value if the type name
 is annotated with `nullable`. When a strongly-typed null value is
 encountered, its type must agree with one of the core types of the
-expected type. For example, if a `nullable::any_of[int, string,
+expected type. For example, if a `any_of: nullable::[int, string,
 struct]` is expected, `5`, `"hi"`, `{}`, `null`, `null.null`, `null.int`,
 `null.string`, and `null.struct` are all valid values, but `null.decimal` is
 not.


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

Fixing `nullable::any_of[int, string, struct]`, which does not match the ISL grammar, nor is it even valid Ion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
