### PR TITLE
Clarifies grammar to indicate that named types cannot be inlined within other named types

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,7 +141,7 @@ schema_header::{         // optional
   ],
 }
 
-<TYPE_DEFINITION>...
+<NAMED_TYPE_DEFINITION>...
 
 schema_footer::{         // optional
 }
@@ -823,8 +823,8 @@ key decisions when creating this specification.
 This section provides a BNF-style grammar for the Ion Schema Language.
 
 ```
-<SCHEMA> ::= <TYPE_DEFINITION>...
-           | <HEADER> <TYPE_DEFINITION>... <FOOTER>
+<SCHEMA> ::= <NAMED_TYPE_DEFINITION>...
+           | <HEADER> <NAMED_TYPE_DEFINITION>... <FOOTER>
 
 <HEADER> ::= schema_header::{
   imports: [ <IMPORT>... ]
@@ -843,8 +843,10 @@ This section provides a BNF-style grammar for the Ion Schema Language.
 <FOOTER> ::= schema_footer::{
 }
 
-<TYPE_DEFINITION> ::= type::{ name: <TYPE_NAME>, <CONSTRAINT>... }
-                    | { <CONSTRAINT>... }
+<NAMED_TYPE_DEFINITION> ::= type::{ name: <TYPE_NAME>, <CONSTRAINT>... }
+
+<UNNAMED_TYPE_DEFINITION> ::= type::{ <CONSTRAINT>... }
+                            | { <CONSTRAINT>... }
 
 <ID> ::= <STRING>
        | <SYMBOL>
@@ -857,8 +859,8 @@ This section provides a BNF-style grammar for the Ion Schema Language.
                    | nullable::<TYPE_NAME>
                    |           <TYPE_ALIAS>
                    | nullable::<TYPE_ALIAS>
-                   |           <TYPE_DEFINITION>
-                   | nullable::<TYPE_DEFINITION>
+                   |           <UNNAMED_TYPE_DEFINITION>
+                   | nullable::<UNNAMED_TYPE_DEFINITION>
                    |           <IMPORT_TYPE>
                    | nullable::<IMPORT_TYPE>
 


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

The ISL _grammar_ indicates that named, inlined types might be allowed, like this:
```ion
type::{
  name: foo,
  type: list,
  element: type::{
    name: bar,
    type: string,
  }
}
```

This contradicts the [Type Definition](https://amzn.github.io/ion-schema/docs/spec.html#type-definitions) section of the spec, which says:
> an _unnamed_ type may be inlined anywhere a <TYPE_REFERENCE> is expected
[emphasis added]

This change updates the grammar to clearly differentiate between named and unnamed types so that it is clear that ISL does not support naming any inlined types. This does not preclude us from allowing named, inline types in the future if the need should arise.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
