### PR TITLE
Defines the set of strings that can be used as ISL keywords

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1049,6 +1049,9 @@ This section provides a BNF-style grammar for the Ion Schema Language.
 
 ```
 
+All Ion Schema Language keywords SHALL use [Snake Case](https://en.wikipedia.org/wiki/Snake_case),
+and SHALL begin with `$` or an alphabetic character.
+
 # Examples
 
 The following examples illustrate how Ion Schema concepts work together,


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Formally limits the possible values that the Ion Schema Language uses as keywords in the future. This will allow ISL users to include user-defined content in a schema or type definition without worrying about whether a future update to ISL will cause a clash between an ISL keyword and the user-defined content. Users can future-proof their user-defined content by choosing field names and annotations that can never become an ISL keyword. For example, a user might choose to use a prefix of `_` or use `PascalCase` or `SCREAMING_SNAKE_CASE`.


It reads a little awkwardly (in my opinion) to have the statement about ISL keywords at the beginning of the "Grammar" section, but I couldn't think of a better spot for it. We can always rearrange things later if we want to.



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
