### PR TITLE
Adds clarification about the `document` type

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -88,7 +88,7 @@ The type system defines the following core types:
       - `lob`: represents a `blob` or `clob`
       - `number`: represents a `decimal`, `float`, or `int`
       - `text`: represents a `string` or `symbol`
-      - `document`: represents a series of top-level values
+      - `document`: similar to an Ion [value stream](https://amzn.github.io/ion-docs/docs/glossary.html#value_stream), this represents a series of top-level values, but unlike a value stream, a `document` cannot be unbounded.
       - `nothing`: has no valid value (useful for reserving a field name)
       - `any`: represents any of the types listed above as well as types
         derived from those types


### PR DESCRIPTION
*Issue #, if available:*

#31

*Description of changes:*

This is probably not a complete solution for #31, but it does provides a little more detail by relating `document` back to the Ion specification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
