### PR TITLE
Adds cookbook section for validating struct fields with all fields optional

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -3,6 +3,60 @@ title:  Ion Schema Language Cookbook
 ---
 # {{ page.title }}
 
+## Optionally ignoring the occurs requirement for fields
+
+Suppose you have a type definition for a struct, and sometimes you want to validate the fields without enforcing the
+required-ness of fields. (A possible use case for this is to perform partial validation on a partially constructed 
+piece of data.) Ion Schema does not provide any flag or option to "turn off" the required-ness of fields, so you can
+model this in Ion Schema by composing two types. In one type, you can define the types of each field, and in another
+type you can define whether a field is required (or more generally, the number of times the field can occur). Finally,
+the type you intended to create can be defined as a composition of these two types you have created.
+
+
+Here is an example using a `Customer` type:
+```ion
+type::{
+  name: CustomerFieldTypes,
+  fields: {
+    title: { valid_values: ["Dr.", "Mr.", "Mrs.", "Ms."] },
+    firstName: string,
+    middleName: string,
+    lastName: string,
+    suffix: { valid_values: ["Jr.", "Sr.", "PhD"] },
+    preferredName: string,
+    customerId: {
+      one_of: [
+        { type: string, codepoint_length: 18 },
+        { type: int, valid_values: range::[100000, 999999] },
+      ],
+    },
+    addresses: { type: list, element: Address },
+    lastUpdated: { timestamp_precision: second },
+  },
+  content: closed,
+}
+
+type::{
+  name: CustomerFieldOccurrences,
+  fields: {
+    firstName: { occurs: required },
+    lastName: { occurs: required },
+    addresses: { occurs: required },
+    customerId: { occurs: required },
+    lastUpdated: { occurs: required },
+  }
+}
+
+type::{
+  name: Customer,
+  all_of: [CustomerFieldTypes, CustomerFieldOccurrences],
+}
+```
+
+When you want to validate only that the fields have the correct types, and that there are no unexpected fields, you can
+test your data against `CustomerFieldTypes`, and when you want the validation to also enforce required fields,
+you can test your data against `Customer`.
+
 ## Expressing logical relationships between fields
 
 Sometimes you may need to model logical relationships between fields. Consider the following:


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

I had an offline conversation with a customer who was looking to solve this particular use case, and it seems like this is a solution that would be useful to share with other people.

See rendered changes at [popematt.github.io/ion-schema](https://popematt.github.io/ion-schema/docs/cookbook.html#optionally-ignoring-the-occurs-requirement-for-fields).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
