### PR TITLE
Remove confusing comment about greedy evaluation of `ordered_elements`

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -719,10 +719,6 @@ of the specified types list. Each type is implicitly defined with
 When specified, this constraint fully defines the content of a list,
 S-expression, or document -- open content is not implicitly allowed.
 
-Note that when a type in a heterogeneous list, S-expression, or document
-may occur some variable number of times, matching against a particular
-type is performed greedily before proceeding to the next type.
-
 > ```
 > ordered_elements: [
 >   string,


### PR DESCRIPTION
*Issue #, if available:*

Resolves #62

*Description of changes:*

Removes the confusing comment. I tried to think of something to replace it with, but anything I could come up with just raised further questions. I'd rather just let people expect that this works in the most intuitive way. (Ie. it's kind of like a regular expression for Ion values. I didn't say that, though, because it's _like_ a regular expression in the strict CS theory sense of the word, not the ECMA 262 sort of regex, and because it does not support grouping like a (strict) regular expression.)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
