### PR TITLE
RFC: Ion Schema 2.0

### DIFF
--- a/rfcs/ion_schema_2_0/ion_schema_2_0.md
+++ b/rfcs/ion_schema_2_0/ion_schema_2_0.md
@@ -5,17 +5,6 @@
   - [Summary](#summary)
   - [Motivation](#motivation)
   - [Description of Changes](#description-of-changes)
-    - [Versioning Rules for the Ion Schema Language](#versioning-rules-for-the-ion-schema-language)
-    - [Open content in Ion Schema 2.0](#open-content-in-ion-schema-20)
-    - [Add `ieee754_float` constraint](#add-ieee754_float-constraint)
-    - [Replace `scale` constraint with `exponent` constraint](#replace-scale-constraint-with-exponent-constraint)
-    - [Replace `nullable::` with `$null_or::`](#replace-nullable-with-null_or)
-    - [Add support for modeling a set](#add-support-for-modeling-a-set)
-    - [Add `field_names` constraint](#add-field_names-constraint)
-    - [Replace `content: closed` with `closed::` modifier for `fields` constraint.](#replace-content-closed-with-closed-modifier-for-fields-constraint)
-    - [Improve `annotations` constraint](#improve-annotations-constraint)
-    - [Add additional regex support](#add-additional-regex-support)
-    - [Change implicit `type: any` to `type: $any`](#change-implicit-type-any-to-type-any)
   - [Compatibility with Ion Schema 1.0](#compatibility-with-ion-schema-10)
   - [Appendix — Below the Line/Out of Scope for Ion Schema 2.0](#appendix--below-the-lineout-of-scope-for-ion-schema-20)
     - [Schema/Type versioning](#schematype-versioning)
@@ -59,48 +48,27 @@ As Ion Schema has been used by customers, customers have asked for some new func
 
 ## Description of Changes
 
-### Versioning Rules for the Ion Schema Language
-
+* **Versioning Rules for the Ion Schema Language**  
 Ion Schema will use a major and minor version numbers. (This was implied in Ion Schema 1.0, but not well-defined.) Any backwards-incompatible change requires a new major version. Any other change to the Ion Schema Language requires a new minor version. Edits to the specification for spelling, grammar, or clarity (i.e. any changes that do not affect the ISL syntax or semantics) do not require a new version of Ion Schema. See [Ion Schema Language Versions](language_versions.md) for full details.
-
-### Open Content in Ion Schema 2.0
-
+* **Open Content in Ion Schema 2.0**   
 Ion Schema 2.0 defines a set of symbols that are reserved for use by future versions of Ion Schema. A user may use a reserved symbol for open content if and only if that field is explicitly declared as user content in the schema header. See [Ion Schema 2.0 Open Content](open_content.md).
-
-### Add `ieee754_float` constraint
-
-If a user wants to model [binary32](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) or [binary16](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) ranges in Ion Schema 1.0, it cannot be done due to precision/scale aspects of binary floating-point. The `ieee7754_float` constraint allows us to constraint float values to be only those values that are precisely representable by a specific IEEE 754 binary encoding. See [ion-schema #18](https://github.com/amzn/ion-schema/issues/18#issuecomment-1092130146).
-
-### Replace `scale` constraint with `exponent` constraint
-
-The `scale` constraint has some unexpected behavior and is at odds with the Ion Decimal data model. Ion Schema 2.0 replaces `scale` with `exponent`, which closely aligns with the Ion `decimal` data model. See [ion-schema #27](https://github.com/amzn/ion-schema/issues/27).
-
-### Replace `nullable::` with `$null_or::`
-
-The `nullable::` annotation is underspecified and behaves in unintuitive ways. A complete solution to correctly identify the allowed types of null is not practical to solve, so `nullable::` will be replaced with `$null_or::` which will be syntactical sugar for a union of `null` (equivalently `null.null`) and the annotated type. See [ion-schema #38](https://github.com/amzn/ion-schema/issues/38#issuecomment-1119833602).
-
-### Add support for modeling a set
-
-Ion Schema 1.0 provides no way to model a set. Ion Schema 2.0 introduces the modifier `distinct::` for the `element` constraint which validates that no two elements in a container may be equivalent Ion values. See [ion-schema #43](https://github.com/amzn/ion-schema/issues/43).
-
-### Add `field_names` constraint
-
-Ion Schema 1.0 provides no way to validate field names except by listing out explicitly which names are allowed in the `fields` constraint. The `field_names` constraint will allow the text of all field name symbols of a struct to be validated according to a specified type. See [ion-schema #44](https://github.com/amzn/ion-schema/issues/44#issuecomment-1097296761).
-
-### Replace `content: closed` with `closed::` modifier for `fields` constraint.
-
+* **Add `ieee754_float` constraint**  
+If a user wants to model [binary32](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) or [binary16](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) ranges in Ion Schema 1.0, it cannot be done due to precision/scale aspects of binary floating-point. The `ieee754_float` constraint allows us to constraint float values to be only those values that are precisely representable by a specific IEEE 754 binary encoding. See [ion-schema #18](https://github.com/amzn/ion-schema/issues/18#issuecomment-1092130146). 
+* **Replace `scale` constraint with `exponent` constraint**  
+The `scale` constraint has some unexpected behavior and is at odds with the Ion Decimal data model. Ion Schema 2.0 replaces `scale` with `exponent`, which closely aligns with the Ion `decimal` data model. See [ion-schema #27](https://github.com/amzn/ion-schema/issues/27). 
+* **Replace `nullable::` with `$null_or::`**  
+The `nullable::` annotation is underspecified and behaves in unintuitive ways. A complete solution to correctly identify the allowed types of null is not practical to solve, so `nullable::` will be replaced with `$null_or::` which will be syntactical sugar for a union of `null` (equivalently `null.null`) and the annotated type. See [ion-schema #38](https://github.com/amzn/ion-schema/issues/38#issuecomment-1119833602). 
+* **Add support for modeling a set**  
+Ion Schema 1.0 provides no way to model a set. Ion Schema 2.0 introduces the modifier `distinct::` for the `element` constraint which validates that no two elements in a container may be equivalent Ion values. See [ion-schema #43](https://github.com/amzn/ion-schema/issues/43). 
+* **Add `field_names` constraint**  
+Ion Schema 1.0 provides no way to validate field names except by listing out explicitly which names are allowed in the `fields` constraint. The `field_names` constraint will allow the text of all field name symbols of a struct to be validated according to a specified type. See [ion-schema #44](https://github.com/amzn/ion-schema/issues/44#issuecomment-1097296761). 
+* **Replace `content: closed` with `closed::` modifier for `fields` constraint.**  
 The `content: closed` (pseudo) constraint only *modifies* the `fields` constraint and is confusing when composing types. It will be removed in Ion Schema 2.0 and replaced with a `closed::` modifier for the `fields` constraint. See [ion-schema #47](https://github.com/amzn/ion-schema/issues/47).
-
-### Improve `annotations` constraint
-
-In Ion Schema 1.0, the `annotations` constraint has some unexpected and useless behaviors, and it is not possible to model rules such as "1 of N annotations" or "any lowercase annotation". Ion Schema 2.0 eliminates the specific configurations that have confusing behavior, and adds syntax to allow annotations to be validated as if they are a `list` of `symbol`. See [ion-schema #51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979).
-
-### Add additional regex support
-
+* **Improve `annotations` constraint**  
+In Ion Schema 1.0, the `annotations` constraint has some unexpected and useless behaviors, and it is not possible to model rules such as "1 of N annotations" or "any lowercase annotation". Ion Schema 2.0 eliminates the specific configurations that have confusing behavior, and adds syntax to allow annotations to be validated as if they are a `list` of `symbol`. See [ion-schema #51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979). 
+* **Add additional regex support**  
 Ion Schema 2.0 adds support for backslash-escaped character sets inside character classes to the subset of supported ECMA regex features. See [ion-schema #54](https://github.com/amzn/ion-schema/issues/54).
-
-### Change implicit `type: any` to `type: $any`
-
+* **Change implicit `type: any` to `type: $any`**  
 In Ion Schema 1.0, the default `type` is `any` rather than the top type, `$any`. This leads to some unintuitive behavior when handling null values. Ion Schema 2.0 changes the default `type` of a type definition from `any` to `$any`. See [ion-schema #58](https://github.com/amzn/ion-schema/issues/58).
 
 ## Compatibility with Ion Schema 1.0

--- a/rfcs/ion_schema_2_0/ion_schema_2_0.md
+++ b/rfcs/ion_schema_2_0/ion_schema_2_0.md
@@ -32,6 +32,7 @@ Ion Schema 2.0 introduces the following changes:
 * [ion-schema #51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979) – Improve modeling of annotations in Ion Schema
 * [ion-schema #54](https://github.com/amzn/ion-schema/issues/54) – Add support for more ECMA 262 regex features
 * [ion-schema #58](https://github.com/amzn/ion-schema/issues/58) – Change the default type from `any` to `$any`
+* [ion-schema #72](https://github.com/amzn/ion-schema/issues/72) – Allow timestamp ranges to have endpoints with unknown offsets
 
 ## Motivation
 
@@ -70,6 +71,8 @@ In Ion Schema 1.0, the `annotations` constraint has some unexpected and useless 
 Ion Schema 2.0 adds support for backslash-escaped character sets inside character classes to the subset of supported ECMA regex features. See [ion-schema #54](https://github.com/amzn/ion-schema/issues/54).
 * **Change implicit `type: any` to `type: $any`**  
 In Ion Schema 1.0, the default `type` is `any` rather than the top type, `$any`. This leads to some unintuitive behavior when handling null values. Ion Schema 2.0 changes the default `type` of a type definition from `any` to `$any`. See [ion-schema #58](https://github.com/amzn/ion-schema/issues/58).
+* **Allow timestamp ranges to have endpoints with unknown offsets**  
+Ion Schema 1.0 prohibits using timestamps with unknown offsets as the upper or lower bound of a timestamp range, which leads to an awkward user experience in some cases. Ion Schema 2.0 allows timestamp ranges to have boundaries with unknown offset. See [ion-schema #72](https://github.com/amzn/ion-schema/issues/72).
 
 ## Compatibility with Ion Schema 1.0
 

--- a/rfcs/ion_schema_2_0/ion_schema_2_0.md
+++ b/rfcs/ion_schema_2_0/ion_schema_2_0.md
@@ -1,0 +1,149 @@
+# RFC: Ion Schema 2.0
+
+<!-- TOC start -->
+- [RFC: Ion Schema 2.0](#rfc-ion-schema-20)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+  - [Description of Changes](#description-of-changes)
+    - [Versioning Rules for the Ion Schema Language](#versioning-rules-for-the-ion-schema-language)
+    - [Open content in Ion Schema 2.0](#open-content-in-ion-schema-20)
+    - [Add `ieee754_float` constraint](#add-ieee754_float-constraint)
+    - [Replace `scale` constraint with `exponent` constraint](#replace-scale-constraint-with-exponent-constraint)
+    - [Replace `nullable::` with `$null_or::`](#replace-nullable-with-null_or)
+    - [Add support for modeling a set](#add-support-for-modeling-a-set)
+    - [Add `field_names` constraint](#add-field_names-constraint)
+    - [Replace `content: closed` with `closed::` modifier for `fields` constraint.](#replace-content-closed-with-closed-modifier-for-fields-constraint)
+    - [Improve `annotations` constraint](#improve-annotations-constraint)
+    - [Add additional regex support](#add-additional-regex-support)
+    - [Change implicit `type: any` to `type: $any`](#change-implicit-type-any-to-type-any)
+  - [Compatibility with Ion Schema 1.0](#compatibility-with-ion-schema-10)
+  - [Appendix — Below the Line/Out of Scope for Ion Schema 2.0](#appendix--below-the-lineout-of-scope-for-ion-schema-20)
+    - [Schema/Type versioning](#schematype-versioning)
+    - [User-Defined Constraints](#user-defined-constraints)
+    - [Other Language Features](#other-language-features)
+    - [Code Generation](#code-generation)
+<!-- TOC end -->
+
+## Summary
+
+This RFC proposes a new major version of the Ion Schema Language: **Ion Schema 2.0**.
+
+Ion Schema 2.0 will be fully interoperable with Ion Schema 1.0.
+
+Ion Schema 2.0 introduces the following changes:
+
+* [Ion Schema Language Versions](language_versions.md)
+* [Ion Schema 2.0 Open Content](open_content.md)
+* [ion-schema #18](https://github.com/amzn/ion-schema/issues/18#issuecomment-1092130146) – Add `ieee754_float` constraint
+* [ion-schema #27](https://github.com/amzn/ion-schema/issues/27) – Replace `scale` constraint with `exponent`
+* [ion-schema #38](https://github.com/amzn/ion-schema/issues/38#issuecomment-1119833602) – Replace `nullable::` modifier with `$null_or::`
+* [ion-schema #43](https://github.com/amzn/ion-schema/issues/43) – Add a way to require that containers have no duplicate elements
+* [ion-schema #44](https://github.com/amzn/ion-schema/issues/44#issuecomment-1097296761) – Allow field names to be constrained without exact field names being specified
+* [ion-schema #47](https://github.com/amzn/ion-schema/issues/47) – Replace `content: closed` with `closed::` modifier for `fields` constraint
+* [ion-schema #51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979) – Improve modeling of annotations in Ion Schema
+* [ion-schema #54](https://github.com/amzn/ion-schema/issues/54) – Add support for more ECMA 262 regex features
+* [ion-schema #58](https://github.com/amzn/ion-schema/issues/58) – Change the default type from `any` to `$any`
+
+## Motivation
+
+[Ion Schema Language](https://amzn.github.io/ion-schema/docs/spec.html) (ISL) is a grammar and constraints for narrowing the universe of Ion values. A schema consists of zero or more types, and a type is a collection of zero or more constraints over the Ion data model.
+
+Ion Schema Language is declarative and is intended to be portable across platforms and programming environments. Therefore, a schema document must have the same behavior on all equivalently configured Ion Schema implementations. If an implementation does not support all features used in a particular schema document, the implementation must error when it attempts to load that schema.
+
+As Ion Schema has been used by customers, customers have asked for some new functionality to address feature gaps, and we identified some misfeatures and points of ambiguity that needed to be addressed. However, we realized that it is impossible to evolve the Ion Schema Language in a way that preserves the portability/compatibility goal. This is because:
+
+* No specification about what requires a major or minor version change.
+* There is no way to tell the difference between open/user content and an unknown feature, so it is impossible to raise an error for an unsupported feature.
+* Every new constraint is a potentially breaking change because it could interfere with someone’s open content.
+* No specification about whether schemas with different ISL versions can import each other
+
+## Description of Changes
+
+### Versioning Rules for the Ion Schema Language
+
+Ion Schema will use a major and minor version numbers. (This was implied in Ion Schema 1.0, but not well-defined.) Any backwards-incompatible change requires a new major version. Any other change to the Ion Schema Language requires a new minor version. Edits to the specification for spelling, grammar, or clarity (i.e. any changes that do not affect the ISL syntax or semantics) do not require a new version of Ion Schema. See [Ion Schema Language Versions](language_versions.md) for full details.
+
+### Open Content in Ion Schema 2.0
+
+Ion Schema 2.0 defines a set of symbols that are reserved for use by future versions of Ion Schema. A user may use a reserved symbol for open content if and only if that field is explicitly declared as user content in the schema header. See [Ion Schema 2.0 Open Content](open_content.md).
+
+### Add `ieee754_float` constraint
+
+If a user wants to model [binary32](https://en.wikipedia.org/wiki/Single-precision_floating-point_format) or [binary16](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) ranges in Ion Schema 1.0, it cannot be done due to precision/scale aspects of binary floating-point. The `ieee7754_float` constraint allows us to constraint float values to be only those values that are precisely representable by a specific IEEE 754 binary encoding. See [ion-schema #18](https://github.com/amzn/ion-schema/issues/18#issuecomment-1092130146).
+
+### Replace `scale` constraint with `exponent` constraint
+
+The `scale` constraint has some unexpected behavior and is at odds with the Ion Decimal data model. Ion Schema 2.0 replaces `scale` with `exponent`, which closely aligns with the Ion `decimal` data model. See [ion-schema #27](https://github.com/amzn/ion-schema/issues/27).
+
+### Replace `nullable::` with `$null_or::`
+
+The `nullable::` annotation is underspecified and behaves in unintuitive ways. A complete solution to correctly identify the allowed types of null is not practical to solve, so `nullable::` will be replaced with `$null_or::` which will be syntactical sugar for a union of `null` (equivalently `null.null`) and the annotated type. See [ion-schema #38](https://github.com/amzn/ion-schema/issues/38#issuecomment-1119833602).
+
+### Add support for modeling a set
+
+Ion Schema 1.0 provides no way to model a set. Ion Schema 2.0 introduces the modifier `distinct::` for the `element` constraint which validates that no two elements in a container may be equivalent Ion values. See [ion-schema #43](https://github.com/amzn/ion-schema/issues/43).
+
+### Add `field_names` constraint
+
+Ion Schema 1.0 provides no way to validate field names except by listing out explicitly which names are allowed in the `fields` constraint. The `field_names` constraint will allow the text of all field name symbols of a struct to be validated according to a specified type. See [ion-schema #44](https://github.com/amzn/ion-schema/issues/44#issuecomment-1097296761).
+
+### Replace `content: closed` with `closed::` modifier for `fields` constraint.
+
+The `content: closed` (pseudo) constraint only *modifies* the `fields` constraint and is confusing when composing types. It will be removed in Ion Schema 2.0 and replaced with a `closed::` modifier for the `fields` constraint. See [ion-schema #47](https://github.com/amzn/ion-schema/issues/47).
+
+### Improve `annotations` constraint
+
+In Ion Schema 1.0, the `annotations` constraint has some unexpected and useless behaviors, and it is not possible to model rules such as "1 of N annotations" or "any lowercase annotation". Ion Schema 2.0 eliminates the specific configurations that have confusing behavior, and adds syntax to allow annotations to be validated as if they are a `list` of `symbol`. See [ion-schema #51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979).
+
+### Add additional regex support
+
+Ion Schema 2.0 adds support for backslash-escaped character sets inside character classes to the subset of supported ECMA regex features. See [ion-schema #54](https://github.com/amzn/ion-schema/issues/54).
+
+### Change implicit `type: any` to `type: $any`
+
+In Ion Schema 1.0, the default `type` is `any` rather than the top type, `$any`. This leads to some unintuitive behavior when handling null values. Ion Schema 2.0 changes the default `type` of a type definition from `any` to `$any`. See [ion-schema #58](https://github.com/amzn/ion-schema/issues/58).
+
+## Compatibility with Ion Schema 1.0
+
+*The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this section are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).*
+
+Ion Schema 2.0 will be fully interoperable with Ion Schema 1.0.
+
+* Any Ion Schema implementation with support for Ion Schema 2.0 MUST also support reading Ion Schema 1.0.
+* Ion Schema 2.0 SHALL allow importing schemas written in Ion Schema 1.0.
+* Any implementation of ISL 1.0 that also implements ISL 2.0 MUST allow types from an ISL 2.0 schema to be imported by an ISL 1.0 schema.
+* The interoperability requirements stated here SHALL NOT apply to Ion Schema 3.0 or any future major version unless that major version explicitly restates them. (i.e., Ion Schema 3.0 is allowed to say that implementations must also support Ion Schema 2.0 but are not required to support Ion Schema 1.0.)
+
+## Appendix — Below the Line/Out of Scope for Ion Schema 2.0
+
+### Schema/Type versioning
+
+Some users have asked about schema versioning, but they have described multiple different versioning strategies. Based on the use cases that we have learned about, there does not appear to be a one-size-fits-all solution for schema versioning. Ion Schema will need to have its own versioning strategy for `ion-schema-schemas`, and we believe that it is possible via name mangling or a custom authority implementation. (One user had already indicated that name mangling is sufficient for their use case.)
+
+We plan to add documentation and examples to suggest some methods for managing multiple versions of schemas, but we do not plan to add any features to Ion Schema 2.0 specifically to support versioned schemas and/or types.
+
+See [ion-schema #66](https://github.com/amzn/ion-schema/issues/66).
+
+### User-Defined Constraints
+
+We considered adding support for user-defined constraints. In Ion Schema 1.0, it is only possible to add a user-defined constraint by creating a custom Ion Schema implementation. In Ion Schema 2.0, this remains possible. Any user-defined constraint would be treated as open content by an implementation that does not support that user-defined constraint.
+
+However, it would be possible to introduce a feature in Ion Schema Language that would allow users to indicate that certain open content fields are actually a user-defined constraint.
+
+Ultimately, we chose to defer this because we are not sure if it is the right thing to do, and we believe we can safely introduce it in a new _minor_ version of the Ion Schema Language by extending the open-content mechanism proposed in [Open Content](open_content.md).
+
+See [ion-schema #68](https://github.com/amzn/ion-schema/issues/68) for spec support for user-defined constraints and [ion-schema-kotlin #33](https://github.com/amzn/ion-schema-kotlin/issues/33) for API support of user-defined constraints.
+
+### Other Language Features
+
+There are several features that we thought of, but they were ultimately excluded because no one has actually asked for the feature (yet). All of these features could safely be introduced in a later *minor* version of Ion Schema, so excluding them is not a one-way door.
+
+* Add a way to indicate that a particular type cannot be imported by any other schema. See [ion-schema #67](https://github.com/amzn/ion-schema/issues/67).
+* Add a way to configure whether number-related constraints should be strict about the Ion type of the number or whether they should use a numerical/mathematical equivalence. See [ion-schema #65](https://github.com/amzn/ion-schema/issues/65).
+* Add a default type for schema document so that users don’t need to make seemingly redundant calls to `getType()` in (for example) `loadSchema("foo.isl").getType("foo").validate(ionValue)`.  See [ion-schema #15](https://github.com/amzn/ion-schema/issues/15).
+* Add a constraint for timestamps that allows for constraining individual fields of the timestamp (e.g. minutes must be a multiple of 5). See [ion-schema #46](https://github.com/amzn/ion-schema/issues/46).
+* Add syntax and support for repeated subsequences in the `ordered_elements` constraint. See [ion-schema #41](https://github.com/amzn/ion-schema/issues/41).
+
+### Code Generation
+
+We would like to create tools for generating code from an Ion Schema, but we concluded it is an orthogonal concern that does not belong in the Ion Schema Language specification. You can comment on code generation for JVM in [ion-schema-kotlin #146](https://github.com/amzn/ion-schema-kotlin/issues/146) or C/C++ code generation in [ion-schema #49](https://github.com/amzn/ion-schema/issues/49), or [open a new issue](https://github.com/amzn/ion-schema/issues/new) for a new code generation target.

--- a/rfcs/ion_schema_2_0/language_versions.md
+++ b/rfcs/ion_schema_2_0/language_versions.md
@@ -1,0 +1,265 @@
+# Ion Schema Language Versions
+
+<!-- TOC start -->
+- [Ion Schema Language Versions](#ion-schema-language-versions)
+  - [Introduction](#introduction)
+  - [Definitions/Glossary](#definitionsglossary)
+  - [Ion Schema Compatibility/Portability Goal](#ion-schema-compatibilityportability-goal)
+  - [Motivation](#motivation)
+    - [Incompatibility across implementation versions](#incompatibility-across-implementation-versions)
+    - [Lack of portability](#lack-of-portability)
+    - [Underspecification of importing across schema versions](#underspecification-of-importing-across-schema-versions)
+    - [Backwards Incompatibility caused by Open Content](#backwards-incompatibility-caused-by-open-content)
+  - [Solution – Ion Schema Language Versioning](#solution--ion-schema-language-versioning)
+    - [What is versioned?](#what-is-versioned)
+    - [How is it versioned?](#how-is-it-versioned)
+      - [Major Versions](#major-versions)
+      - [Minor Versions](#minor-versions)
+    - [Examples of different types of changes](#examples-of-different-types-of-changes)
+    - [ISL Version Marker Syntax and Implementation](#isl-version-marker-syntax-and-implementation)
+      - [Implications for Schema Imports](#implications-for-schema-imports)
+      - [Examples – Ion Schema 1.0](#examples--ion-schema-10)
+      - [Examples – Ion Schema >=2.0](#examples--ion-schema-20)
+  - [Alternatives Considered](#alternatives-considered)
+    - [Semantic Versioning](#semantic-versioning)
+    - [Only track major versions of ISL](#only-track-major-versions-of-isl)
+    - [Calendar Versioning (CalVer)](#calendar-versioning-calver)
+    - [Include a promise about semantic equivalence for major version updates](#include-a-promise-about-semantic-equivalence-for-major-version-updates)
+  - [Frequently Asked Questions](#frequently-asked-questions)
+    - [Does Ion Schema provide any features for versioning of users’ schemas or types?](#does-ion-schema-provide-any-features-for-versioning-of-users-schemas-or-types)
+    - [When an implementation adds support for a new ISL major version, must an implementation that follows SemVer also bump its major version?](#when-an-implementation-adds-support-for-a-new-isl-major-version-must-an-implementation-that-follows-semver-also-bump-its-major-version)
+<!-- TOC end -->
+
+## Introduction
+
+The purpose of this document is to specify how the Ion Schema Language will be versioned.
+
+*The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).*
+
+## Definitions/Glossary
+
+* **Ion Schema Language (ISL):** the syntax, grammar, and set of constraints for validating Ion data, as well as the rules that govern how an Ion Schema implementation should interpret and apply schemas to Ion data.
+* **Ion Schema Language (ISL) version:** a specific version of the Ion Schema Language; synonymous with "Ion Schema version" and "language version"
+* **Ion Schema Specification:** the text that describes the Ion Schema Language.
+* **Implementation version**: the (release) version of a library that implements the Ion Schema Specification, such as `ion-schema-kotlin` or `ion-schema-rust`
+* **Schema Document**: A single stream of ion values that conforms to the Ion Schema Specification. (In IonJava terms, an IonDatagram that conforms to the spec.)
+* **Schema Version**: refers to versions of user-defined schemas/types. Schema versions are not in scope for this document, but it is defined here to clearly differentiate it from the other types of "version" that are mentioned.
+* **User defined content (UDC)**: optional content that has no meaning to the schema system but may have meaning to the end user
+
+## Ion Schema Compatibility/Portability Goal
+
+A schema document MUST have the same behavior on all equivalently configured Ion Schema implementations. If an implementation does not support all features used in a particular schema document, the implementation MUST error when it attempts to load that schema.
+
+## Motivation
+
+The Ion Schema 1.0 Specification [requires version markers](https://amzn.github.io/ion-schema/docs/spec.html#schema-definitions) at the start of a schema document, but the specification says nothing else about how Ion Schema is to be versioned. Without clear versioning rules, almost any functional change to the Ion Schema specification is a potentially breaking change for our customers.
+
+### Incompatibility across implementation versions
+
+We cannot change the meaning or behavior of any existing language syntax in a backwards compatible way. If the meaning of any syntax is modified, then schemas would no longer portable because they could behave differently in different applications that take a dependency on different releases of a library that implements Ion Schema.
+
+### Lack of portability
+
+Any behavioral change to the Ion Schema specification is not guaranteed to be portable across different libraries that implement Ion Schema. These libraries will not be updated at exactly the same time, and users of Ion Schema will not update their dependencies at exactly the same time (or possibly never update their dependencies). Ion Schema needs a clearly defined versioning strategy that allows users to specify which behavior to use for a given schema document.
+
+### Underspecification of importing across schema versions
+
+For Ion Schema use cases that have a large number of schemas, perhaps owned by multiple teams, we currently provide no guidance regarding whether schemas with different versions can be used together (i.e. can a schema import another schema with a different version?). Users will not be able to safely use multiple ISL versions or gradually upgrade their ISL version if this remains undefined.
+
+### Backwards Incompatibility caused by Open Content
+
+There can be no Ion Schema 1.1—as long as open content is allowed, almost any change is backwards incompatible. ISL 1.0 broadly allows user-defined ("open") content and so any new syntax has the possibility of name-shadowing user-defined content, causing unexpected behavior. However, restricting user defined content would itself be a backwards incompatible change. This backwards incompatible change will require a new major version, but before that can happen, Ion Schema needs a versioning strategy.
+
+## Solution – Ion Schema Language Versioning
+
+*This solution assumes that Ion Schema 2.0 also introduces some rules to prevent open content from colliding with Ion Schema features. See [Ion Schema 2.0 Open Content](open_content.md)*
+
+### What is versioned?
+
+The *Ion Schema Language* SHALL be versioned. The documents that describe the Ion Schema Language (the specification) SHALL NOT have versioned releases.
+
+### How is it versioned?
+
+The Ion Schema Language version SHALL consist of a major and minor version components. The major and minor version components SHALL be non-negative integers.
+
+Within a schema document, the format SHALL be `$ion_schema_<major>_<minor>`. In the specification text and other documentation, it SHALL be `<major>.<minor>`.
+
+Readers may notice that this is similar to [Semantic Versioning](https://semver.org/). However, it differs in two key ways. Semantic Versioning includes patch versions, but Ion Schema Language versioning does not use patch versions. Semantic Versioning is specific that [releases must be immutable](https://semver.org/#spec-item-3), but Ion Schema Language versioning does not provide that guarantee. The Ion Schema Language may be modified without changing the version number when the modification is an unsubstantive clarification or bugfix.
+
+#### Major Versions
+
+A new major version MAY contain any sort of changes, including backwards incompatible changes. Upon creating a new major version, the minor version component SHALL be reset to `0`.
+
+#### Minor Versions
+
+Each new minor version of the Ion Schema Language SHALL allow any Ion Schema document that is valid against any previous minor version of the Ion Schema Language, within the same major version, to be updated to the new Specification version with equivalent semantics. Such an update MUST only require changing the ISL version marker to the new minor version. For example, a valid Ion Schema 2.2 document, upon changing its ISL version marker to `$ion_schema_2_3`, SHALL be a valid Ion Schema 2.3 document, semantically equivalent to the original Ion Schema 2.2 document. New minor versions of the Ion Schema Specification MUST be written to ensure this form of backward compatibility. 
+
+The guarantee of backwards compatibility is the objective standard by which we differentiate a major and minor version. Without some sort of objective standard, all we have are good intentions in order to decide whether a change requires a new major or minor version.
+
+A change that qualifies as a minor version update MAY be released as a major version update as a way to signal to users that it is a particularly large or significant change.
+
+### Examples of different types of changes
+
+Any change that is not backwards compatible must be released as a new major version. In other words, given the latest released version N, if we create version N+1, and there are any possible schemas for version N that are not valid and semantically equivalent by simply changing the ISL version marker to N+1, then a new major version is required. Examples of this include placing new restrictions on user-defined content, removing functionality, or changing the ISL versioning rules.
+
+Any backwards compatible behavior or syntax change can be released as a new minor version. Examples of this include adding new behavior with new syntax to an existing constraint (such as a new modifier), adding a new constraint (assuming open content is appropriately limited), or adding syntactical sugar.
+
+Some behavior clarifications may be released as an update to an existing minor version. Examples include reclassifying `occurs` to not be a constraint ([ion-schema#48](https://github.com/amzn/ion-schema/pull/48)) and clarifying the interactions between number ranges and special float values ([ion-schema#56](https://github.com/amzn/ion-schema/pull/56)).
+
+Changes to the Ion Schema Specification that do not affect the Ion Schema Language are out of scope for Ion Schema Language versioning—for example, spelling and grammar changes, adding examples, or renumbering sections of the specification.
+
+### ISL Version Marker Syntax and Implementation
+
+The ISL version marker in a schema document will only specify the major and minor version. The patch version is not included in the ISL version marker because patch versions do not change the behavior of the schema, so they have no relevance in a schema document.
+
+The Ion Schema specification [requires ISL version markers](https://amzn.github.io/ion-schema/docs/spec.html#schema-definitions), but the `ion-schema-kotlin` implementation [does not enforce that requirement](https://github.com/amzn/ion-schema-kotlin/blob/master/src/com/amazon/ionschema/internal/SchemaImpl.kt#L78). Starting with Ion Schema 2.0, a version marker must be required, but to avoid breaking existing schemas, we must continue to interpret the absence of an ISL version marker as an implied `$ion_schema_1_0`. (*Refer to [Backwards Incompatibility caused by Open Content](#backwards-incompatibility-caused-by-open-content)* *for why we must go directly to Ion Schema 2.0.*)
+
+* **The keyspace reserved for ISL version markers SHALL be the set of symbols that matches the regular expression `^\$ion_schema_\d.*$`.** Any top-level symbol matching this regular expression must be interpreted as an ISL version marker (regardless of whether it refers to a valid ISL version).
+  *Why?* We want to avoid any ambiguity or potential confusion for human readers when they see a value that looks like an ISL version marker.(Note that the Ion spec already reserves the `$ion` prefix for Ion and related applications.)
+* **A *valid* ISL version marker SHALL match the regular expression `^\$ion_schema_[1-9]\d*_(0|[1-9]\d*)$`.**
+  *Why?* A valid ISL version marker must contain a major and minor version indicator. No leading zeros are allowed.
+* **The first value in the schema SHOULD be an ISL Version Marker.**
+  *Why?* This is the version-independent convention for signaling the ISL version.
+* **If a top-level ISL value is encountered before encountering an ISL version marker, implementations MUST assume `$ion_schema_1_0`.**
+  *Why?* This behavior is required for backwards compatibility, since the ISL version marker is not enforced for ISL 1.0
+* **An ISL Version Marker in the form `$ion_schema_X_Y` SHALL indicate that X and Y are the major and minor version respectively.**
+  *Why?* This is the version-independent convention for signaling the ISL version.
+* **If any ISL Version Marker is not a valid/supported version marker, implementations MUST raise an error.**
+  *Why?* Implementations must raise an error to meet [the portability/compatibility goal](#ion-schema-compatibilityportability-goal).
+* **If more than one Ion Schema version marker is found in the value stream of a single Ion Schema, the implementation MUST raise an error.**
+  *Why?* Because when there are multiple version markers, we cannot determine which version to use if those versions are different. *Caveat—the Ion Schema Specification does not define how to find the boundaries of a schema document in an Ion stream. Ion Schema Authorities MAY choose to support a means of having more than one schema document contained in a stream of Ion Values, but an Authority MUST return at most 1 schema for a given schema id.*
+* **If an implementation supports ISL version `X.Y`, then it MUST also support ISL version `X.Y-1`** **(recursively down to `X.0`)**.
+  *Why?* Easier for customers to move between minor versions of their schemas. Helps us to guarantee that minor versions are import compatible with each other. It also simplifies the `ion-tests` repository because we can organize and run tests by major version instead of having to re-run them for every minor version—which also helps validate that minor version updates are indeed backwards compatible.
+
+#### Implications for Schema Imports
+
+From [Minor Versions](#minor-versions):
+
+> Each new minor version of the Ion Schema Specification SHALL allow any Ion Schema document that is valid against any previous minor version of the Specification, within the same major version, to be updated to the new Specification version with equivalent semantics. Such an update MUST only require changing the ISL version marker to the new minor version.
+
+Under this condition, any schema that uses imports must remain semantically equivalent, without requiring anything of the imported schema, so by implication, Ion Schema must allow importing schemas that are still on prior minor versions.
+
+Because ISL supports cycles in schema dependency graphs, we can infer that **a schema SHALL be allowed to import another schema that uses *any* other minor version in the same major version**. For example, given a dependency of A → B → A, where both A and B are using Ion Schema 2.0, when A is updated to 2.1, A must be allowed to import B and B must be allowed to import A.
+
+(In other words, any schema using Ion Schema `X.a` MUST be able to import any other schema using Ion Schema `X.b`, both minor versions are supported by the Ion Schema implementation. Since an Ion Schema implementation must always provide support for all prior minor versions for a given major version, it is always possible to import a schema with any different minor version, *up to the highest minor version supported by that implementation*.)
+
+The Ion Schema Specification does not restrict the possible changes that are allowed in a new major version, so **any new major version of Ion Schema SHALL define its own rules regarding the ability to import schemas from prior major versions of Ion Schema**. A new major version SHOULD allow importing from the most recent prior major version unless there is a technical reason why it is not possible.
+
+#### Examples – Ion Schema 1.0
+
+```
+// The first value is not an ISL version marker, so it is implicitly ISL 1.0
+
+$foo_service_interface_version_1 // Open content
+
+$ion_schema_1_0 // Ion Schema 1.0 allows out-of-place version markers 
+                // because in Ion Schema 1.0 this is open content.
+
+$ion_schema_2_0 // Ion Schema 1.0 does not allow version 
+                // markers that are for a different version
+
+schema_header::{}
+
+// ... other content ...
+
+schema_footer::{}
+```
+
+```
+$ion_schema_1_0  // Explicit version marker
+ 
+$ion_schema_1_0 // Ion Schema 1.0 allows out-of-place version markers 
+                // because in Ion Schema 1.0 this is open content.
+
+schema_header::{}
+
+// ... other content ...
+
+schema_footer::{}
+```
+
+#### Examples – Ion Schema >=2.0
+
+```
+$ion_schema_2_4           // <-- isl version marker
+
+$foo_service_interface_version_1  // <-- allowed open content
+
+$ion_schema_2_4           // <-- ion schema version marker in wrong position
+$ion_schema_1_foo         // <-- not allowed as open content
+
+schema_header::{
+  imports: [
+    { id: fruit, type: apple },
+  ]
+}
+
+type::{
+  name: ion_schema_version_marker,
+  type symbol,
+  valid_values: [ 
+    $ion_schema_1_0,     // <-- all valid; 
+    $ion_schema_2_0,     // <   not isl version markers because 
+    $ion_schema_2_1,     // <   they are not a top level values.
+    $ion_schema_cat_dog, // <
+  ]
+}
+
+schema_footer::{}
+```
+
+## Alternatives Considered
+
+#### Semantic Versioning
+
+Using [Semantic Versioning](https://semver.org/) (SemVer) would require patch versions. The chosen solution has no use for patch versions, so we would need to find something to do with patch versions. We could either leave the patch version to always be `0` or we could use patch versions to version non-behavioural changes in the documentation. If we always keep the patch version at `0`, then we have no benefit of using SemVer. If we use patch versions for documentation changes, then we are imposing an unnecessary process on ourselves and future maintainers of the project, and adding complexity that will probably confuse Ion Schema users with no obvious benefit to those users.
+
+#### Only track major versions of ISL
+
+While this is possible, it does not benefit our customers as much as tracking minor versions. By tracking minor versions, we get the following benefits over tracking only major versions:
+
+* Ability to define easy/intuitive rules about backwards compatibility for implementations
+* Ability to define straightforward rules about importing schemas of mixed versions
+* Minor versions are a signal for customers to know how much effort it is for them to upgrade the ISL version of their schemas
+
+#### Calendar Versioning (CalVer)
+
+"[CalVer](https://calver.org/) is a versioning convention based on the project's release calendar, instead of arbitrary numbers." It can be used in conjunction with (modified) SemVer or on its own. For example, one could choose to use the year as the major version while following SemVer for the minor and patch versions.
+
+CalVer has the benefit (for developers/maintainers) that you do not need to determine backwards compatibility to decide whether a release should be a new major version—instead you release a new major version with all the feature changes on a pre-determined schedule. However, if we use a calendar-based major version, then we cannot provide consistent guarantees about the compatibility between different versions of the Ion Schema Language, which is not as good for Ion Schema users.
+
+CalVer also has the (general) benefit of making it easy to tie releases to a particular support schedule. This may be useful for a specific *software application*, but it seems to be irrelevant for a *specification*.
+
+If we use CalVer, it seems like there would be an implied expectation of a specific release schedule. We do not want the spec to be updated on a specific schedule because we want to be able to react to business needs (for example, release a new major version without having to wait for the next calendar year). On the other hand, we do not want to be making releases solely because it is the predetermined time for a release—we expect the frequency of Ion Schema Specification releases to decrease over time as the specification matures.
+
+Finally, this is a minor consideration, but the Ion Schema 1.0 Specification is already implied to use a versioning scheme (though none is defined) that is not calendar based, so precedent would suggest that we stick to non-calendar-based versioning.
+
+#### Include a promise about semantic equivalence for major version updates
+
+We could include the following:
+
+>Given a valid schema document for a particular major version, when the ISL version marker is changed to the next major version, the schema document SHALL either be (1) a semantically equivalent schema document or (2) not a valid schema document.
+
+In other words:
+
+>Changing only the ISL version marker MUST NOT result in a valid but semantically different schema document, even when changing major versions.
+
+This would make it safer for customers to upgrade their schemas because when they update the ISL version marker, it eliminates the possibility of having a valid but semantically different schema document. In addition, it simplifies the implementation of Ion Schema because there would be no need for implementations to push any versioning concerns to the constraint implementations.
+
+However, the implication is that a major version update *cannot change the meaning of any existing syntax*—it can only remove features from ISL. (Though in the case of a constraint, for example, the constraint may be re-introduced with altered functionality under a different name.) This could add a disproportionately large amount of friction for seemingly small changes that result in a change of meaning, such as changing whether `+/-inf` are inside the `max/min` range bounds.
+
+We decided not to do this because upgrading major versions should be an infrequent occurrence. If a change is significant enough to require a new major version, then it will probably be non-trivial for users to update their schemas to a new version. Since it would be non-trivial, we would provide a tool to help Ion Schema users upgrade to the latest version. Furthermore, this promise would make it more difficult for us to introduce changes to ISL.
+
+## Frequently Asked Questions
+
+#### Does Ion Schema provide any features for versioning of users’ schemas or types?
+
+ISL 1.0 does not provide any special functionality for schema versions. That is up to the discretion of the end user. However, the Ion Schema cookbook should provide suggestions.
+
+Why does ISL not have schema versioning? Customers have asked about schema versioning, but they have described multiple different versioning strategies, and Ion Schema is not at a point right now where we can choose one to be the blessed way of versioning schemas/types.
+
+However, Ion Schema will need to choose a versioning strategy for Ion Schema Schemas, because there will need to be multiple versions of the schema schemas. This will be a forcing function for Ion Schema to document schema versioning approaches for the Ion Schema cookbook.
+
+#### When an implementation adds support for a new ISL major version, must an implementation that follows SemVer also bump its major version?
+
+No. Adding support for a new ISL version never *requires* the implementation to increase its major version because it is strictly adding functionality. However, if an implementation (that follows SemVer) ever *drops* support for an older version of ISL, that would require a new major version under the SemVer rules.

--- a/rfcs/ion_schema_2_0/open_content.md
+++ b/rfcs/ion_schema_2_0/open_content.md
@@ -1,0 +1,548 @@
+# Ion Schema 2.0 Open Content
+
+<!-- TOC start -->
+- [Ion Schema 2.0 Open Content](#ion-schema-20-open-content)
+  - [Introduction](#introduction)
+  - [Definitions/Glossary](#definitionsglossary)
+  - [Motivation](#motivation)
+     - [The meaning of "open content" is underspecified](#the-meaning-of-open-content-is-underspecified)
+     - [Lack of reserved words interferes with the evolution of Ion Schema](#lack-of-reserved-words-interferes-with-the-evolution-of-ion-schema)
+     - [Known Use-Cases Differ from the Specification](#known-use-cases-differ-from-the-specification)
+  - [Solution](#solution)
+     - [Definition of Reserved and Un-Reserved Symbols](#definition-of-reserved-and-un-reserved-symbols)
+     - [Open Content in Ion Schema Language Structures](#open-content-in-ion-schema-language-structures)
+     - [Repeated Field Names](#repeated-field-names)
+     - [Additional Top Level Values](#additional-top-level-values)
+     - [Any other content is prohibited](#any-other-content-is-prohibited)
+  - [Alternatives Considered](#alternatives-considered)
+     - [Relying on Casing/Sigils](#relying-on-casingsigils)
+     - [Enforcing stylistic choices](#enforcing-stylistic-choices)
+     - [Set of unreserved symbols](#set-of-unreserved-symbols)
+     - [Do not allow open content to shadow built-in constraints of ISL](#do-not-allow-open-content-to-shadow-built-in-constraints-of-isl)
+     - [Allow Ion Schema 2.0 keywords to be name-shadowed](#allow-ion-schema-20-keywords-to-be-name-shadowed)
+     - [Designate a specific field for user content, and do not allow anywhere else](#designate-a-specific-field-for-user-content-and-do-not-allow-anywhere-else)
+     - [Alternatives for Top-Level Open Content](#alternatives-for-top-level-open-content)
+  - [Appendix – FAQ](#appendix--faq)
+     - [Repeated field names seems like an antipattern; what should we do about that?](#repeated-field-names-seems-like-an-antipattern-what-should-we-do-about-that)
+     - [What about field names with unusual characters?](#what-about-field-names-with-unusual-characters)
+     - [Exactly what sort of open content is allowed now?](#exactly-what-sort-of-open-content-is-allowed-now)
+     - [Is there a syntax we could use for sharing user-content declarations between multiple schemas?](#is-there-a-syntax-we-could-use-for-sharing-user-content-declarations-between-multiple-schemas)
+  - [Appendix – Open Content Edge Cases in Ion Schema 1.0](#appendix--open-content-edge-cases-in-ion-schema-10)
+<!-- TOC end -->
+
+## Introduction
+
+The purpose of this document is to specify the nature of allowed "open content" within an Ion Schema document so that we can avoid conflicts between user defined content, extensions, and unreleased language features.
+
+This document does not seek to address whether "open content" in an Ion Schema document can be associated with any particular functionality (such as custom constraint behavior).
+
+This document builds upon changes proposed in  [Ion Schema Language Versions](language_versions.md) and assumes the reader is familiar with that document.
+
+*The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).*
+
+## Definitions/Glossary
+
+* **Ion Schema Language (ISL):** the syntax, grammar, and set of constraints for validating Ion data, as well as the rules that govern how an Ion Schema implementation should interpret and apply schemas to Ion data.
+* **Schema Document**: A single stream of Ion values that conforms to the Ion Schema grammar. (In IonJava terms, an IonDatagram that conforms to an Ion Schema specification.)  A schema may be a subsequence of a larger stream of Ion values, but it is the responsibility of Authority implementations to provide zero-or-one schemas for a given schema ID.
+* **Open Content**: Additional information in an Ion Schema document that is not part of the Ion Schema Language
+* **Reserved symbol:** A symbol that is reserved for use by the Ion Schema Language
+* **Key Word:** A reserved symbol that is given a meaning by (i.e. part of) the Ion Schema Language
+* **Unreserved symbol:** A symbols that will never be used by the Ion Schema Language
+* **Ion-reserved symbol:** A symbol that is reserved by the Ion specification—"By convention, symbols starting with `$` should be reserved for system tools, processing frameworks, and the like, and should be avoided by applications and end users. In particular, the symbol `$ion` and all symbols starting with `$ion_` are reserved for use by the Ion notation and by related standards."
+* **Snake Case:** A style of writing where spaces between words are represented by underscores (`_`) and letters are lowercase
+
+## Motivation
+
+### The meaning of "open content" is underspecified
+
+The Ion Schema 1.0 Specification says:
+
+>ISL itself allows for open content – additional information may be specified within a type definition (or schema_header / schema_footer), and such additional content is simply ignored. [[source](https://amzn.github.io/ion-schema/docs/spec.html#open-content)]
+
+This does not describe where in the type definition, header, or footer the extra data may occur. Does this mean that unknown field names are allowed? Does this mean that extra values or annotations for a constraint may be specified?
+It does not describe how repeated fields are to be handled within these structs (are they repeated constraints, or are they considered "additional information"—ie. open content?).
+
+### Lack of reserved words interferes with the evolution of Ion Schema
+
+When it was released in 2018, Ion Schema 1.0 had no reserved or unreserved symbols. In September 2021, in response to a user question, Ion Schema 1.0 was updated to have unreserved symbols ([ion-schema #50](https://github.com/amzn/ion-schema/pull/50)). This change placed limits on Ion Schema, effectively reserving a set of words for users that can never become Ion Schema keywords in the future. This is beneficial for customers because they can add open content using those words as field names without worrying about conflict with future keywords, but it does not provide any reserved symbols for Ion Schema’s use.
+
+Because Ion Schema 1.0 has no reserved symbols, any new feature that is added to the language has a chance of conflicting with a user’s "open content", thereby making the change backwards incompatible. Ion Schema 1.0’s open content causes almost any new feature to require a new major version of the Ion Schema specification.
+
+[Ion Schema Language Versions](language_versions.md) defines a contract for new versions of Ion Schema, and in order to have backwards compatible changes, we need to put more guard rails around open content for Ion Schema 2.0
+
+### Known Use-Cases Differ from the Specification
+
+Finally, the Ion Schema reference implementation ([Ion Schema Kotlin](https://github.com/amzn/ion-schema-kotlin)) is more permissive about open content than the Ion Schema 1.0 specification. This has enabled customer use cases that were not originally intended by the Ion Schema specification. (For example, one internal customer is known to use a top-level symbol to indicate the version of their API that the schema corresponds to, and [ion-schema-tests](https://github.com/amzn/ion-schema-tests) adds test cases as top-level values in schema documents.) Even though these may not have been intended, the fact that customers are using top-level open content is a strong signal that we should allow some provision for it in the specification.
+
+## Solution
+
+### Definition of Reserved and Un-Reserved Symbols
+
+The set of *reserved symbols* SHALL be all symbols matching the regular expression `($ion_schema(_.*)?|[a-z][a-z0-9]*(_[a-z0-9]+)*)`. Informally stated, this is the symbol `$ion_schema`, all symbols starting with `$ion_schema_`, and all [identifier symbols](https://amzn.github.io/ion-docs/docs/spec.html#symbol) that are *snake case* and start with an unaccented ascii, lower-case letter.
+
+The set of *un-reserved symbols* SHALL be the complement of the set of reserved symbols.
+
+##### Keywords
+
+A keyword is a reserved symbol that has been assigned a meaning by the Ion Schema specification.
+
+Whether a reserved symbol is considered a keyword is context dependent.
+
+* Within a type definition, the keywords SHALL be `name`, `occurs`, and `id` , as well as all the constraints defined in this version of the Ion Schema specification.
+* Within the schema header, the keywords SHALL be `imports` and `user_content`.
+* There are no keywords in a schema footer.
+
+### Open Content in Ion Schema Language Structures
+
+Within a type definition, schema header, or schema footer, *unreserved symbols* may freely be used as field names for additional content. For example:
+
+```
+schema_header::{
+  _info: "This schema is about penguins."
+}
+type::{
+  name: adelie,
+  type: penguin,
+  _region: antarctica,
+  _crested: false,
+  _banded: false,
+}
+type::{
+  name: humboldt,
+  type: penguin,
+  _region: south_america,
+  _crested: false,
+  _banded: true,
+}
+schema_footer::{}
+```
+
+In order to use a *reserved symbol* for additional content, the use of that word must be declared in the schema header. In addition, an individual declaration is scoped to one of `schema_header`, `type`, or  `schema_footer`. For example:
+
+```
+schema_header::{
+  imports: [
+    // ...
+  ],
+  // This is valid open content even though the `user_content` struct comes "after" 
+  // it because structs are unordered.
+  foo: 1,
+  user_content: {
+    schema_header: [
+      // foo is only available in the header
+      foo,
+      // documentation is declared for the header, and later also declared for type
+      documentation,
+    ]
+    type: [
+      documentation,
+      should_index,
+    ],
+  },
+  documentation: "This schema is for ...",
+}
+
+type:: {
+  name: product_title,
+  documentation: '''product_title isn't sanitised, so beware of the potential for code injection attacks''',
+  type: string,
+  codepoint_length: range::[1, 50],
+  should_index: true,
+}
+
+schema_footer::{}
+```
+
+#### Name Shadowing of Keywords
+
+Name shadowing is when a user reserves the same symbol text as an element of the Ion Schema language. Ion Schema 2.x must allow name shadowing in order for it to be possible for a new keyword to be introduced as a minor version upgrade by the rules set forth in [Language Versions: Minor Versions](language_versions.md#minor-versions). (For example, if a user has reserved `foo` and Ion Schema 2.Y+1 introduces `foo` as a keyword, allowing name-shadowing means that upgrading from Ion Schema 2.Y to 2.Y+1 is backwards compatible. Prohibiting name-shadowing would cause Ion Schema 2.Y+1 to be incompatible with Ion Schema 2.Y, and so 2.Y would actually have to be 3.0.) Be careful—*if a user reserves a keyword, it will effectively disable that keyword*. For example, if a user reserves `is_prime`, and a future version of Ion Schema introduces an `is_prime` constraint, `is_prime` will function as open content rather than provide the new constraint functionality.
+
+Ion Schema 2.0 keywords may not be shadowed—only keywords introduced in Ion Schema >= 2.1. This is because name-shadowing a keyword is a concession to preserve backwards compatibility, not a feature in and of itself.
+
+
+### Repeated Field Names
+
+When two or more fields have the same name, they SHALL be the same type of content. (I.e. all shall be considered *open content* or all shall be considered a constraint.) This is because Ion structs are unordered, so we are not guaranteed to choose a "first" or "second" instance in a consistent way. Therefore, in order to ensure that the behavior of the schema is the same across all implementations, all instances of a field name must be treated equally.
+
+In the first type of this example, both occurrences of `regex` are constraints that must be evaluated by an Ion Schema implementation. The two types in this example are functionally equivalent.
+
+```
+type::{
+  regex: "[0-9]*",
+  regex: ".{8}"
+}
+
+type::{
+  all_of:[
+    { regex: "[0-9]*" },
+    { regex: ".{8}" },
+  ]
+}
+```
+
+Duplicate constraints are evaluated like any other constraint in a type definition. If any constraint is unsatisfied then the data is considered invalid, and each constraint reports separate (if any) violations.
+
+### Additional Top Level Values
+
+An Ion Schema MAY include extra top-level values that are not explicitly specified in the Ion Schema specification, but any top-level open content MUST NOT be annotated with a *reserved symbol*. Note that Ion Schema version markers are always interpreted as Ion Schema version markers and can never be valid open content. (See [Ion Schema Language Versions: ISL Version Marker Syntax and Implementation](language_versions.md#isl-version-marker-syntax-and-implementation)). Ion Schema implementations MAY provide APIs to read the top-level open content, but are not required to do so.
+
+Examples:
+```
+[1, 2, 3]        // <-- Valid open content
+$type::[1, 2, 3] // <-- valid open content
+type::[1, 2, 3]  // <-- Invalid type definition
+
+// Valid open content
+$test_case::{
+  type: positive_int,
+  valid: [ 1, 2, 3 ],
+  invalid: [ -1, 0, null.int, true, 2.0, 2e0, "two" ],
+}
+
+// All are valid open content, but be careful because they each use symbols starting
+// with $ion_ which are reserved by the Amazon Ion Specification.
+$ion_foo      
+$ion_foo::{ a:1 }
+$ion_schema
+$ion_schema_x
+
+// Not valid open content because of the reserved symbol annotation
+foo::$ion_bar
+
+// All are invalid as open content because of the use of $ion_schema... annotation
+$ion_schema_foo::{}
+$ion_schema_2_0::{}
+
+// ISL version markers -- not open content
+$ion_schema_38483_59879823 // <-- Invalid Ion Schema Version Marker, not valid as open content
+$ion_schema_2_0            // <-- Valid Ion Schema Version Marker, but not valid
+                           //     as open content. 
+```
+
+### Any other content is prohibited
+
+If a stream of Ion values contains any _open content_ other than what is specified above, that stream of values SHALL NOT be a valid Ion Schema.
+
+Some examples of illegal _open content_ include:
+
+```
+schema_header::aardvark::{ // Illegal extra annotation 'aardvark'
+  imports: [
+    // Illegal annotation 'armadillo' on an import
+    armadillo::{ id: 'mammals/felines/leopards.isl' },
+    // Illegal field 'stripes' in an import
+    { id: 'mammals/felines/tigers.isl' stripes: true },
+  ],
+  user_content: {
+    type: [
+      tarsir
+    ]
+  },
+  // Illegal open content because "tarsir" was declared in the type definition scope.
+  tarsir: 123,
+}
+
+$ion_schema_123_456 // ISL version marker is never open content
+
+type::type::{ // Illegal repetition of 'type' annotation
+  name: snow::leopard, // Illegal annotation on type name
+  type: feline,
+}
+
+// Invalid use of `type` annotation for something that is not a type definition
+type::(lemur ::= indri | ring_tailed | aye_aye | sifakas)
+
+// Reserved symbol not allowed for top-level annotation
+penguin::[
+  macaroni, king, emperor, gentoo,
+  rockhopper, humboldt, chinstrap,
+  magellan, galapagos, adelie,
+]
+
+```
+
+## Alternatives Considered
+
+### Relying on Casing/Sigils
+
+Should the "open content" rules *rely on* any sort of style or casing of field names? (E.g. `$` prefix indicates a custom constraint, no prefix is a reserved word, `_` prefix or non-snake case indicates user data.)
+
+As much as possible, we do not want to rely on [sigils](https://en.wikipedia.org/wiki/Sigil_(computer_programming)) or casing to indicate the meaning of a field name. Casing is particularly problematic because it breaks down for characters that are not obviously upper or lower case (such as ‘1’, ‘🥧’, ‘$’, ‘_’, or characters in some non-Latin alphabets). Sigils would remove the need to declare user-reserved words, but limit the flexibility of mixing ISL with some other framework (e.g. fields that are directives for a hypothetical Ion 1.1 template generator).
+
+### Enforcing stylistic choices
+
+Should the open content rules *enforce* any sort of style or casing of field names?
+
+Should we have a single, blessed syntax/style for user-defined content, or should we allow anything that does not conflict with the symbols that are reserved for Ion Schema?
+
+Example of a so-called mixed-style struct
+
+```
+type::{
+  name: foo,
+  type: string,
+  $foo: 1,
+  BAR: 2,
+  _baz: 3,
+  FooBar: 4,
+  '🙁' : '🥦'
+  '😄' : '🍰'
+}
+```
+
+Mixed-style structs might look ugly, but there is no technical reason for such a rule. If we care about the aesthetics of ISL, then we should consider writing a rule for an Ion Schema linter.
+
+### Set of unreserved symbols
+
+Should unreserved symbols be...
+
+1. **Anything that does not match `($ion_schema(_.*)?|[a-z][a-z0-9]*(_[a-z0-9]+)*)`**
+   This is the preferred solution presented in this document.
+2. **Anything that does not match `($ion_schema(_.*)?|[a-zA-Z]).*`**
+   This is unnecessarily restrictive. We have chosen to use snake case for Ion Schema Language keywords, so we have no need to reserve uppercase letters.
+3. **Anything that matches `[$_].*` but not `$ion_schema(_.*)?`**
+   The difference between this option, and option 1 is subtle. Option 1 allows open content identifiers such as `'--foo'` and `BAR`, whereas this option only allows unreserved symbols to start with `$` and `_`. This option is unnecessarily restrictive because Ion Schema will never try to introduce a keyword that is not an Ion identifier symbol.
+
+**Should  `$isl(_.*)?` also be reserved?**
+
+No. The ISL version marker has already set a precedent of using `$ion_schema` for Ion Schema system-level symbols.
+
+Ultimately, the choice of reserving the `$ion_schema` prefix and snake-case symbols is because it seems to be a minimal subset of all symbols that gives room for Ion Schema to evolve without having exact knowledge of the future, and it has a relatively low cognitive burden for developers learning to use Ion Schema.
+
+### Do not allow open content to shadow built-in constraints of ISL
+
+While this seems like it would simplify things, it actually has the same problem of open content right now. Specifically, that any new ISL constraints would have the potential of conflicting with a new constraint, which would either change the behavior of a schema or render the schema invalid, and so any new constraint would require a new major version.
+
+### Allow Ion Schema 2.0 keywords to be name-shadowed
+
+It was originally considered to allow any reserved word to be used for user content, including ISL keywords. However, this presented some problems.
+
+**Name-shadowing certain keywords introduces implementation problems**
+
+Certain keywords will cause problems when name-shadowed by user content.
+
+* **`id` in a type definition**. This could cause an inline type to be indistinguishable from an inline import in some cases
+* **`name` in a type definition**. Needs to occur only once, unless we want to start allowing this as a way to provide multiple names for a type. (Actually, that is not a terrible idea.) Even if you override this, however, top-level types still need a name—where would it come from? All top-level types must have a name in order for a schema to be valid.
+* **`user_content` in schema header**. Overriding `user_content` leads to a paradox because the implementation cannot know that `user_content` is name-shadowed until reading the `user_content` field with its original semantics, but if `user_content` is overridden, then it cannot be used to define overrides.
+* **`occurs` in a type definition**. If overridden, does everything always have the default `occurs` value? It is probably a bad idea, but it is technically possible.
+
+
+**Possible Mitigations**
+
+Open content theoretically *could* use `name`, but because all top-level types must still have a name, there would be conflict between the `name` open-content and `name` of the type. This could be mitigated by requiring that the name of the type be a single field with a symbol value, and all `name` fields that are not symbols are simply ignored for the purpose of determining the type name. Things that consume the open-content `name` fields could choose to use or ignore the actual type name. The ability to use `name` could be useful for layering a nominal type system on top of ISL using a custom constraint, though a name like `nominal_type` for the custom constraint might be a better idea to avoid confusion.
+
+Custom constraints theoretically *could* use `id`, but there is a potential to be unable to distinguish between inline imports and type definitions. This could be mitigated by specifying that an un-annotated struct containing exactly one `type` field and one `id` field will always be considered an inline import. If other fields are present, or if the annotation `type::` is present, then it will be considered an inline type definition.
+
+Allowing `name` and `id` to be used for custom constraints adds complexity to implementations and introduces edge cases that make the ISL rules more difficult for the developer to understand. Since there is no immediate use case for allowing `name` or `id` to be name-shadowed by a custom constraint, it seems like the simpler solution is to not allow these fields for open content. It would be a backwards compatible change if we decided, in a future version of ISL, to allow shadowing of `name` or `id`.
+
+There is no clear mitigation for the paradox of name-shadowing `user_content` in the header.
+
+Each of these mitigations adds non-trivial amounts of implementation complexity and cognitive burden for Ion Schema users, so this was deemed unacceptable as a solution.
+
+**Special classes of keywords**
+
+Another alternative was to allow some keywords to be overridden, but not others. The keywords `id`, `name`, `user_content`, and `type` were proposed, but it was impossible to come up with a logical way to divide up those keywords that can be name-shadowed, and those that cannot. If `type` is special, and cannot be name-shadowed, then so should its complement `not`. If both `type` and `not`, then so should all the algebraic and aggregation constraints—`all_of`, `any_of`, `one_of`, `element`, `fields`, and `ordered_elements`. This creates a slippery slope situation where it becomes increasingly untenable to argue that any known (as of Ion Schema 2.0) keyword should be allowed to be overridden.
+
+Therefore, it was deemed simplest to prohibit name-shadowing of any Ion Schema 2.0 keyword. This is a two-way door decision, as we can easily allow it in a future minor version if a use case arises. On the other hand, allowing name-shadowing of Ion Schema 2.0 keywords would be a (relatively speaking) one-way door decision, since taking away that capability would require a new major version on Ion Schema.
+
+### Designate a specific field for user content, and do not allow anywhere else
+
+Rather than allowing arbitrary user keys inside type definition structs, we could define a single field for user-defined content. A straw-man proposal for such a field would be `user_content`. This field could appear any number of times and have any value of any type. The biggest reason for this approach is that it is easier to implement because the schema system would not need to check the field names against a regex to determine whether a field is user content or not—there is only ever one field name for user content.
+
+Ultimately, this was rejected as being too restrictive for users of Ion Schema with no actual benefit for implementations because the proposal for custom constraints would require arbitrary fields in a type definition anyway.
+
+### Alternatives for Top-Level Open Content
+
+**(A) No top-level open content**
+Pros:
+
+* Easy to implement
+* Easy for users to understand
+* Allows us to add a new top-level value to ISL without needing a major version bump.
+
+Cons:
+
+* This means that IF anyone wants to put non-ISL into a schema, they must filter the open content out before passing it to the Schema System
+* If you are using the workaround, then when ISL adds new top-level values, it could break customers unless any customer filtering logic is appropriately updated for the new ISL version... but we cannot guarantee that custom code will do that.
+
+Option A is rejected because customers must resort to workarounds to support their existing use cases. (Even if we think they are arguably flimsy use cases.) If we make them implement the workaround, it will likely be brittle. If we implement the workaround, we are basically doing (C).
+
+This is not a customer-obsessed solution because it ignores real-world use cases and makes things harder for customers who have already started using this.
+
+**(B) Top level content allowed in the ISL file/stream before the start of the schema and after the end of the schema.**
+
+This supports the current known use cases of ISL tests and service interface version markers (e.g. `$foo_service_interface_1_0`).
+
+If anyone does want top-level content in the middle, they have to resort to the workaround for (A).
+
+How do we define the start and end of a schema? Suppose we have this:
+
+```
+type::{ ... }
+$foo
+type::{ ... }
+```
+
+Is this an invalid schema, or is the second type actually just open content? (Or maybe the first type is open content, and the second type is the schema?) The only way that we can resolve this consistently is to say that `type`, `schema_header`, `$ion_schema.*`, `schema_footer` are not allowed as open content, even after the end or before the beginning of a schema. (And so then we can assume that any of these are part of the schema.)
+
+At this point, we have arrived at solution (C) with the additional restriction that open content cannot be in the middle of the schema.
+
+Reasons for option B:
+
+* It supports the known use cases
+* It errs on the side of being restrictive; it is no more permissive than it needs to be.
+
+Reasons against option B:
+
+* It is more restrictive than it needs to be
+* The rules for where open content can occur are more complicated than they need to be (higher cognitive burden for users).
+* Has all the potential pitfalls of (A)—with lower likelihood, though—without the benefits of (A).
+
+**(C) Allow anything as open content as long as it is not part of the Ion Schema language (e.g. version markers, headers, types, footers) and it does not use the `\$ion_schema(_*)?` reserved symbols.**
+
+* Easy to implement
+* Easy for users to understand
+* Allows us to add a new top-level value to ISL without needing a major version bump by using an `$ion_schema_.*` annotation for introducing new language features.
+
+Option C is preferable over Option B because it has a lower cognitive burden for Ion Schema users.
+
+**(D) PREFERRED – Reserved and unreserved space**
+Treat like fields in ISL structs. There is a reserved space and an unreserved space. However, unlike constraints, there is no way to override it (as of Ion Schema 2.0).
+
+
+## Appendix – FAQ
+
+#### Repeated field names seems like an antipattern; what should we do about that?
+
+Create an Ion Schema linter. (See [ion-schema #60](https://github.com/amzn/ion-schema/issues/60).)
+
+#### What about field names with unusual characters?
+
+Field names such as ‘🥧_foo’, ‘   ’, ‘é∑å®ê’ are allowed, but often a bad idea.
+
+To warn against foot-guns, we can create a linter rule that warns for any field names that are not [identifiers](https://amzn.github.io/ion-docs/docs/symbols.html#symbol-representations).
+
+>**Identifier**: an unquoted sequence of one or more ASCII letters, digits, or the characters `$` (dollar sign) or `_` (underscore), not starting with a digit.
+
+(source: [Ion Specification§Symbols](https://amzn.github.io/ion-docs/docs/spec.html#symbol))
+
+#### Exactly what sort of open content is allowed now?
+
+It depends on what you mean by "allowed". The specification says little about open content in the schema, and the open content allowed by the reference implementation is more permissive than the specification.
+
+**Specification:**
+
+>ISL itself allows for open content – additional information may be specified within a type definition (or schema_header / schema_footer), and such additional content is simply ignored.
+
+No other type of open content is explicitly allowed or prohibited.
+
+**Implementation:**
+
+* Extra fields inside a type definition
+* Extra top-level values in the schema document
+* Extra annotations on type definitions, headers, footers, imports, some constraint arguments
+* Extra fields inside an import definition
+* Any non-struct inside the imports list
+* Any non-list value for the `imports` field in the header
+* Anything inside the footer
+* Anything can be labelled as `schema_footer::` — null, struct, list, symbol, boolean
+* You can have multiple schema headers and multiple schema footers
+* Things that are not structs can be labelled as types. Eg. `type::[1, 2, 3]`
+
+#### Is there a syntax we could use for sharing user-content declarations between multiple schemas?
+
+This has been deemed out of scope for Ion Schema 2.0, but in a future version, it would be possible to introduce a syntax that is something like this:
+
+```
+$ion_schema_2_0
+schema_header::{
+  imports: [
+    user_content::{ id: foo }, // Imports the extensions defined in foo
+    { id: foo, type: bar}
+  ]
+}
+```
+
+## Appendix – Open Content Edge Cases in Ion Schema 1.0
+This is an assortment of edge cases that are not well-defined in Ion Schema 1.0
+
+Is this type named "foo", "bar", "foo" and "bar", or should this be an error?
+
+```
+type::{
+  name: foo,
+  name: bar,
+  type: string,
+  codepoint_length: range::[min, 10]
+}
+```
+
+Are the elements of this list Employees, Students, people who are both Employees and Students, or is the schema invalid?
+
+```
+type::{
+  name: PeopleList,
+  type: list,
+  element: Student,
+  element: Employee
+}
+```
+
+Are all of these `foo::` annotations allowed? Are they part of the type definition for the purposes of open content?
+
+```
+type::foo::{
+  name: foo::string_list,
+   type: foo::list,
+   container_length: foo::range::[1, foo::10],
+   element: foo::string
+}
+```
+
+Is this a valid schema? If so, what gets imported to this schema?
+
+```
+schema_header::{
+   imports: [
+    { id: a, type: aaa }
+   ],
+   imports: [
+     { id: b, type: bbb }
+   ]
+}
+// Is this open content or a second header?
+schema_header::{
+  imports: [
+    { id: c, type: ccc }
+  ],
+  imports: [
+    { id: d, type: ddd }
+  ]
+}
+
+schema_footer::{}
+```
+
+Are all of these extra annotations allowed? (This is a valid schema according to `ion-schema-kotlin@v1.2.1`!)
+
+```
+type::$ion_schema_1_0
+
+type::schema_header::schema_footer::{
+  imports: [ 
+    schema_header::{
+      id: foo,
+      imports: [ 
+        { id: foo },
+      ]
+    }
+  ]
+}
+
+type::schema_footer::{
+  name: schema_footer::my_type,
+  type: schema_footer::string,
+}
+
+schema_footer::{}
+```

--- a/rfcs/ion_schema_2_0/open_content.md
+++ b/rfcs/ion_schema_2_0/open_content.md
@@ -457,7 +457,7 @@ This has been deemed out of scope for Ion Schema 2.0, but in a future version, i
 $ion_schema_2_0
 schema_header::{
   imports: [
-    user_content::{ id: foo }, // Imports the extensions defined in foo
+    user_content::{ id: foo }, // Imports the user content words defined in foo
     { id: foo, type: bar}
   ]
 }


### PR DESCRIPTION
**Description of Changes**
This PR is for a RFC introducing a new version of Ion Schema.

Ion Schema 2.0 will be fully interoperable with Ion Schema 1.0, and includes the following changes:

* [Ion Schema Language Versions](language_versions.md)
* [Ion Schema 2.0 Open Content](open_content.md)
* [ion-schema#18](https://github.com/amzn/ion-schema/issues/18#issuecomment-1092130146) – Add `ieee754_float` constraint
* [ion-schema#27](https://github.com/amzn/ion-schema/issues/27) – Replace `scale` constraint with `exponent`
* [ion-schema#38](https://github.com/amzn/ion-schema/issues/38#issuecomment-1119833602) – Replace `nullable::` modifier with `$null_or::`
* [ion-schema#43](https://github.com/amzn/ion-schema/issues/43) – Add a way to require that containers have no duplicate elements
* [ion-schema#44](https://github.com/amzn/ion-schema/issues/44#issuecomment-1097296761) – Allow field names to be constrained without exact field names being specified
* [ion-schema#47](https://github.com/amzn/ion-schema/issues/47) – Replace `content: closed` with `closed::` modifier for `fields` constraint
* [ion-schema#51](https://github.com/amzn/ion-schema/issues/51#issuecomment-1105688979) – Improve modeling of annotations in Ion Schema
* [ion-schema#54](https://github.com/amzn/ion-schema/issues/54) – Add support for more ECMA 262 regex features
* [ion-schema#58](https://github.com/amzn/ion-schema/issues/58) – Change the default type from `any` to `$any`
* [ion-schema#72](https://github.com/amzn/ion-schema/issues/72) – Allow timestamp ranges to have endpoints with unknown offsets


### --> [Rendered view](https://github.com/amzn/ion-schema/blob/208165adb10c889949252e7ccd926862bfe60019/rfcs/ion_schema_2_0/ion_schema_2_0.md) <-- 



_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
