### PR TITLE
Allow prepopulating sandbox using query params in the URL

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -172,6 +172,45 @@ pre {
   }
 }
 
+/*
+ Snackbar
+ */
+#snackbar {
+  visibility: hidden;
+  min-width: 250px;
+  margin-left: -125px;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 2px;
+  padding: 16px;
+  position: fixed;
+  z-index: 1;
+  left: 50%;
+  bottom: 30px;
+  font-size: 17px;
+}
+#snackbar.show {
+  visibility: visible;
+  -webkit-animation: fadein 0.5s, fadeout 0.5s 2.5s;
+  animation: fadein 0.5s, fadeout 0.5s 2.5s;
+}
+@-webkit-keyframes fadein {
+  from {bottom: 0; opacity: 0;}
+  to {bottom: 30px; opacity: 1;}
+}
+@keyframes fadein {
+  from {bottom: 0; opacity: 0;}
+  to {bottom: 30px; opacity: 1;}
+}
+@-webkit-keyframes fadeout {
+  from {bottom: 30px; opacity: 1;}
+  to {bottom: 0; opacity: 0;}
+}
+@keyframes fadeout {
+  from {bottom: 30px; opacity: 1;}
+  to {bottom: 0; opacity: 0;}
+}
 
 /**
  * Wrapper

--- a/sandbox.md
+++ b/sandbox.md
@@ -20,10 +20,13 @@ Enter a single Ion value.
 <label for="schema_type">Validate as </label>
 <input type="text" id="schema_type" placeholder="e.g. my_type" name="schema_type" size="15"/>
 <button id="validate" type="submit">Go</button>
+<button id="share" type="submit" title="Share a link to your schema" style="float: right;"><i class="fa fa-share-alt" aria-hidden="true"></i></button>
 
 <div id="resultdiv" class="bs-callout bs-callout-default">
 <h4 id="result"></h4>
 <pre id="violation"></pre>
 </div>
+
+<div id="snackbar"></div>
 
 <script async type="module" src="assets/ion-schema-widget.js"></script>

--- a/sandbox.md
+++ b/sandbox.md
@@ -20,7 +20,7 @@ Enter a single Ion value.
 <label for="schema_type">Validate as </label>
 <input type="text" id="schema_type" placeholder="e.g. my_type" name="schema_type" size="15"/>
 <button id="validate" type="submit">Go</button>
-<button id="share" type="submit" title="Share a link to your schema" style="float: right;"><i class="fa fa-share-alt" aria-hidden="true"></i></button>
+<button id="share" type="submit" title="Share a link to your schema" style="float: right;"><i class="fa fa-share-square-o" aria-hidden="true"></i></button>
 
 <div id="resultdiv" class="bs-callout bs-callout-default">
 <h4 id="result"></h4>


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

* Input boxes can now be pre-populated using query params in the URL
* There's a button to generate a url and put it into your clipboard for sharing

Example link:
https://popematt.github.io/ion-schema/sandbox?schema=type%3A%3A%7B%0A%20%20name%3A%20greeting_sexp%2C%0A%20%20type%3A%20sexp%2C%0A%20%20element%3A%20%7B%0A%20%20%20%20codepoint_length%3A%20range%3A%3A%5B1%2C%2010%5D%2C%0A%20%20%7D%0A%7D&value=(Greetings%20Earthling!)&type=greeting_sexp

See these changes in action—follow the link above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
