### PR TITLE
Clarify apparent contradiction for `valid_values`

### DIFF
--- a/docs/isl-2-0/spec.md
+++ b/docs/isl-2-0/spec.md
@@ -583,7 +583,7 @@ For text that is guaranteed to contain only ASCII code points, `utf8_byte_length
 
 {% include grammar-element.md productions="valid_values,value_or_range,number_range,timestamp_range" %}
 
-A list of acceptable, non-annotated values; any values not present in the list are invalid.
+A list of acceptable values or ranges of values; any values not present in the list (or range) are invalid.
 The argument to this constraint can be a range or a list of unannotated values or a list containing a mix of ranges and unannotated values.
 
 Ignoring annotations, the value must match one of the list of valid values or be within the boundaries of a range.


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

The phrase 

> A list of acceptable, non-annotated values

could sound like ranges are not allowed, since they are annotated with `range::`.
This updates the sentence so that there is no longer an apparent contradiction. It intentionally makes this sentence _less_ specific, allowing the details to be explained in the following sentences.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
