### PR TITLE
Change `user_content` to `user_fields`

### DIFF
--- a/_includes/grammar-2-0.txt
+++ b/_includes/grammar-2-0.txt
@@ -6,7 +6,7 @@
 <HEADER> ::= schema_header::{ <HEADER_FIELD>... }
 
 <HEADER_FIELD> ::= <IMPORTS_DECLARATION>
-                 | <USER_CONTENT_DECLARATION>
+                 | <USER_FIELDS_DECLARATION>
 
 <IMPORTS_DECLARATION> ::= imports: [ <IMPORT>... ],
 
@@ -20,11 +20,11 @@
 
 <IMPORT_TYPE_ALIAS> ::= { id: <SCHEMA_ID>, type: <TYPE_NAME>, as: <TYPE_NAME> }
 
-<USER_CONTENT_DECLARATION> ::= user_content: { <USER_CONTENT_DECLARATION_FIELD>... }
+<USER_FIELDS_DECLARATION> ::= user_fields: { <USER_FIELDS_DECLARATION_FIELD>... }
 
-<USER_CONTENT_DECLARATION_FIELD> ::= schema_header: [ <SYMBOL>... ],
-                                   | type: [ <SYMBOL>... ],
-                                   | schema_footer: [ <SYMBOL>... ],
+<USER_FIELDS_DECLARATION_FIELD> ::= schema_header: [ <SYMBOL>... ],
+                                  | type: [ <SYMBOL>... ],
+                                  | schema_footer: [ <SYMBOL>... ],
 
 <FOOTER> ::= schema_footer::{ }
 

--- a/docs/isl-2-0/spec.md
+++ b/docs/isl-2-0/spec.md
@@ -35,7 +35,7 @@ A schema is a collection of types that can be used to constrain the Ion data mod
 
 A schema consists of a schema version marker `$ion_schema_2_0` followed by an optional schema header, zero or more type definitions, and an optional schema footer.
 The schema header is a struct, annotated with `schema_header`, with an optional `imports` field for leveraging types from other schemas.
-The schema header may also have an optional `user_content` field that is used to declared reserved symbols that are to be used for open content.
+The schema header may also have an optional `user_fields` field that is used to declared reserved symbols that are to be used for open content fields.
 The schema footer is a struct that it annotated with `schema_footer`.
 While a header and footer are both optional, a footer is required if a header is present (and vice-versa).
 A schema may not have more than one header or more than one footer.
@@ -640,21 +640,21 @@ The value `null.timestamp` is never in the bounds of a timestamp range, and `tim
 
 # Open Content
 
-{% include grammar-element.md productions="user_content_declaration,user_content_declaration_field" %}
+{% include grammar-element.md productions="user_fields_declaration,user_fields_declaration_field" %}
 
 The Ion Schema 2.0 specification allows users to insert additional content that is not part of the Ion Schema language into a schema document.
 This additional content may be used for documentation, integrations with other tools or frameworks, or any other desired purpose.
 
 A schema header, type definition, or schema footer may include extra fields that are not explicitly stated in the Ion Schema specification.
 These extra fields may have any field name that is not a *keyword*.
-If the field name is a *reserved symbol*, its use as open content must be declared in the appropriate subfield of the `user_content` field in the schema header.
-For example, the reserved symbol `list_type` may be used in a type definition if `user_content: { type: [ list_type ] }` is present in the schema header.
+If the field name is a *reserved symbol*, its use as open content must be declared in the appropriate subfield of the `user_fields` field in the schema header.
+For example, the reserved symbol `list_type` may be used in a type definition if `user_fields: { type: [ list_type ] }` is present in the schema header.
 
 {% capture sample_code %}
 ```ion
 schema_header::{
   info: "This schema is about penguins.",
-  user_content: {
+  user_fields: {
     schema_header: [info],
     type: [region, crested, banded],
   }
@@ -774,7 +774,7 @@ schema_header
 timestamp_offset
 timestamp_precision
 type
-user_content
+user_fields
 utf8_byte_length
 valid_values
 ```

--- a/docs/isl-2-0/spec.md
+++ b/docs/isl-2-0/spec.md
@@ -194,7 +194,7 @@ Each constraint that accepts a variably-occurring type reference specifies what 
 It is permitted to use a nullable type reference wherever a variably-occurring type reference is accepted.
 However, the `$null_or` annotation may not be applied to any variably-occurring type with an explicit `occurs` field.
 
-{% include example.md title="Correct ways to construct a variably-occurring, nullable type" markdown="
+{% include example.md title="Correct ways to construct a variably-occurring, nullable type" markdown='
 ```ion
 type::{
   name: foo,
@@ -209,7 +209,7 @@ type::{
   ]
 }
 ```
-" %}
+' %}
 
 # Constraints
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

The term `user_content` is easy to confuse with "open content". In order to get rid of that possible source of confusion, this PR changes the `user_content` field to `user_fields`. User fields are a specific type of open content—fields added to a header, footer, or type that are not part of ISL and get their meaning from a user of ISL.

Questions:
* Would it be more precise to call this `user_field_names`?


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
