### PR TITLE
Changes 'type argument' to 'type reference' and adds examples

### DIFF
--- a/_includes/grammar-2-0.txt
+++ b/_includes/grammar-2-0.txt
@@ -37,20 +37,20 @@
 
 <TYPE_NAME> ::= <SYMBOL>
 
-<TYPE_REFERENCE> ::=           <TYPE_NAME>
-                   | $null_or::<TYPE_NAME>
-                   |           <INLINE_TYPE_DEFINITION>
-                   | $null_or::<INLINE_TYPE_DEFINITION>
-                   |           <IMPORT_TYPE>
-                   | $null_or::<IMPORT_TYPE>
+<TYPE_ARGUMENT> ::=           <TYPE_NAME>
+                  | $null_or::<TYPE_NAME>
+                  |           <INLINE_TYPE_DEFINITION>
+                  | $null_or::<INLINE_TYPE_DEFINITION>
+                  |           <IMPORT_TYPE>
+                  | $null_or::<IMPORT_TYPE>
 
 <OCCURS> ::= occurs: <INT>
            | occurs: <RANGE_INT>
            | occurs: optional
            | occurs: required
 
-<VARIABLY_OCCURRING_TYPE_REFERENCE> ::= { <OCCURS>, <CONSTRAINT>... }
-                                      | <TYPE_REFERENCE>
+<VARIABLY_OCCURRING_TYPE_ARGUMENT> ::= { <OCCURS>, <CONSTRAINT>... }
+                                     | <TYPE_ARGUMENT>
 
 <NUMBER> ::= <DECIMAL>
            | <FLOAT>
@@ -98,15 +98,15 @@
                | <TYPE>
                | <VALID_VALUES>
 
-<ALL_OF> ::= all_of: [ <TYPE_REFERENCE>... ]
+<ALL_OF> ::= all_of: [ <TYPE_ARGUMENT>... ]
 
 <ANNOTATIONS_MODIFIER> ::= required::
                          | closed::
 
 <ANNOTATIONS> ::= annotations: <ANNOTATIONS_MODIFIER>... [ <SYMBOL>... ]
-                | annotations: <TYPE_REFERENCE>
+                | annotations: <TYPE_ARGUMENT>
 
-<ANY_OF> ::= any_of: [ <TYPE_REFERENCE>... ]
+<ANY_OF> ::= any_of: [ <TYPE_ARGUMENT>... ]
 
 <BYTE_LENGTH> ::= byte_length: <INT>
                 | byte_length: <RANGE_INT>
@@ -119,29 +119,29 @@
 
 <CONTAINS> ::= contains: [ <VALUE>... ]
 
-<ELEMENT> ::= element: <TYPE_REFERENCE>
-            | element: distinct::<TYPE_REFERENCE>
+<ELEMENT> ::= element: <TYPE_ARGUMENT>
+            | element: distinct::<TYPE_ARGUMENT>
 
 <EXPONENT> ::= exponent: <INT>
              | exponent: <RANGE_INT>
 
-<FIELD> ::= <SYMBOL>: <VARIABLY_OCCURRING_TYPE_REFERENCE>
+<FIELD> ::= <SYMBOL>: <VARIABLY_OCCURRING_TYPE_ARGUMENT>
 
 <FIELDS> ::= fields: { <FIELD>... }
            | fields: closed::{ <FIELD>... }
 
-<FIELD_NAMES> ::= field_names: <TYPE_REFERENCE>
-                | field_names: distinct::<TYPE_REFERENCE>
+<FIELD_NAMES> ::= field_names: <TYPE_ARGUMENT>
+                | field_names: distinct::<TYPE_ARGUMENT>
 
 <IEEE754_FLOAT> ::= ieee754_float: binary16
                   | ieee754_float: binary32
                   | ieee754_float: binary64
 
-<NOT> ::= not: <TYPE_REFERENCE>
+<NOT> ::= not: <TYPE_ARGUMENT>
 
-<ONE_OF> ::= one_of: [ <TYPE_REFERENCE>... ]
+<ONE_OF> ::= one_of: [ <TYPE_ARGUMENT>... ]
 
-<ORDERED_ELEMENTS> ::= ordered_elements: [ <VARIABLY_OCCURRING_TYPE_REFERENCE>... ]
+<ORDERED_ELEMENTS> ::= ordered_elements: [ <VARIABLY_OCCURRING_TYPE_ARGUMENT>... ]
 
 <PRECISION> ::= precision: <INT>
               | precision: <RANGE_INT>
@@ -165,7 +165,7 @@
 <TIMESTAMP_PRECISION> ::= timestamp_precision: <TIMESTAMP_PRECISION_VALUE>
                         | timestamp_precision: <RANGE_TIMESTAMP_PRECISION>
 
-<TYPE> ::= type: <TYPE_REFERENCE>
+<TYPE> ::= type: <TYPE_ARGUMENT>
 
 <UTF8_BYTE_LENGTH> ::= utf8_byte_length: <INT>
                      | utf8_byte_length: <RANGE_INT>


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Renames "Type Reference" to "Type Argument" in the ISL 2.0 specification. "Type Argument" is much clearer about the purpose and avoids confusion with something that is an actual reference (e.g. a reference in Rust, a type name that is a reference to another type, etc.).

Also adds more examples for type definitions and arguments in the spec.

As long as this PR is open, you can see the rendered new version here: https://popematt.github.io/ion-schema/docs/isl-2-0/spec#type-definitions

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
