### PR TITLE
Corrects ISL 1.0 spec to say that `contains` can apply to structs

### DIFF
--- a/docs/isl-1-0/spec.md
+++ b/docs/isl-1-0/spec.md
@@ -41,10 +41,10 @@ assumes that readers are familiar with the Ion data model defined in the
     * [timestamp_precision](#timestamp_precision)
   * [Container Constraints](#container-constraints)
     * [container_length](#container_length)
+    * [contains](#contains)
     * [content](#content)
     * [element](#element)
   * [List/S-expression/Document Constraints](#lists-expressiondocument-constraints)
-    * [contains](#contains)
     * [ordered_elements](#ordered_elements)
   * [Struct Constraints](#struct-constraints)
     * [fields](#fields)
@@ -671,6 +671,18 @@ S-expression, or document, or fields in a struct.
 > container_length: range::[10, 100]
 > ```
 
+### contains
+
+<code><b>contains:</b> [ <i>&lt;VALUE&gt;...</i> ]</code>
+
+Indicates that the list, S-expression, struct, or document is expected to contain all of
+the specified values, in no particular order.
+
+> ```
+> contains: [high]
+> contains: [1, 4.0, high, "apple"]
+> ```
+
 ### element
 
 <code><b>element:</b> <i>&lt;TYPE_REFERENCE&gt;</i></code><br/>
@@ -684,18 +696,6 @@ homogeneous list, S-expression, struct, or document.
 > ```
 
 ## List/S-expression/Document Constraints
-
-### contains
-
-<code><b>contains:</b> [ <i>&lt;VALUE&gt;...</i> ]</code>
-
-Indicates that the list, S-expression, or document is expected to contain all of
-the specified values, in no particular order.
-
-> ```
-> contains: [high]
-> contains: [1, 4.0, high, "apple"]
-> ```
 
 ### ordered_elements
 


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

The ISL 1.0 spec says that `contains` applies to a list, s-expression, or document. However, the reference implementation of Ion Schema has _always_ allowed `contains` to apply to a struct.

I think it makes most sense to say that the ISL 1.0 spec was wrong, and the reference implementation was right. This also keeps `contains` consistent between ISL 1.0 and 2.0.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
