### PR TITLE
Adds constraint that was accidentally omitted from the list of keywords

### DIFF
--- a/docs/isl-2-0/spec.md
+++ b/docs/isl-2-0/spec.md
@@ -886,6 +886,7 @@ exponent
 field_names
 fields
 id
+ieee754_float
 imports
 name
 not


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

The `ieee754_float` constraint was left out of the list of keywords by mistake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
